### PR TITLE
Switch default decimals attribute value to INF and update number formatting code

### DIFF
--- a/src/mireport/excelprocessor.py
+++ b/src/mireport/excelprocessor.py
@@ -44,7 +44,7 @@ from mireport.taxonomy import (
     getTaxonomy,
     listTaxonomies,
 )
-from mireport.xbrlreport import FactBuilder, InlineReport, _FactValue
+from mireport.xbrlreport import FactBuilder, FactValue, InlineReport
 
 L = logging.getLogger(__name__)
 
@@ -1335,7 +1335,7 @@ class ExcelProcessor:
                     continue
 
             fb.setConcept(concept)
-            if isinstance(value, _FactValue):
+            if isinstance(value, FactValue):
                 fb.setValue(value)
             else:
                 self._results.addMessage(

--- a/src/mireport/excelutil.py
+++ b/src/mireport/excelutil.py
@@ -116,10 +116,13 @@ def getNamedRanges(wb: Workbook) -> dict:
     return data
 
 
-def get_decimal_places(cell: _CellType) -> int:
+def get_decimal_places(cell: CellType) -> DecimalPlaces:
     """
-    Returns the number of decimal places in the cell's number format.
-    For example, a format of '0.00' would return 2.
+    Returns the number of decimal places in the cell's number format. For
+    example, a format of '0.00' would return 2.
+
+    If no decimal places are specified, return Literal['INF'], meaning infinite
+    precision, include all digits in display.
     """
     number_format = cell.number_format
 
@@ -138,7 +141,7 @@ def get_decimal_places(cell: _CellType) -> int:
     if match_sci:
         return len(match_sci.group(1))
 
-    return 0  # No decimal part found
+    return "INF"
 
 
 @overload

--- a/src/mireport/localise.py
+++ b/src/mireport/localise.py
@@ -169,10 +169,13 @@ def getBestSupportedLanguage(
     supportedLanguages: frozenset[str],
     defaultLanguage: str | None,
 ) -> str | None:
-    """Return the best supported language included with the taxonomy for the given requested language.
+    """
+    Return the best supported language included with the taxonomy for the given requested language.
 
     @requestedLanguage: Should be as specified in BCP 47. For example, "fr-CH", "en-us", "de".
-    @supportedLanguages"""
+    @supportedLanguages: set of supported languages to choose from
+    @defaultLanguage: Language to pick from supported languages if no close match to requested language can be found, or None if there is no default.
+    """
     if defaultLanguage is not None and defaultLanguage not in supportedLanguages:
         raise ValueError(
             f"Default language must either be None or one of the supported languages {supportedLanguages=}"

--- a/src/mireport/localise.py
+++ b/src/mireport/localise.py
@@ -1,10 +1,12 @@
 import argparse
 import logging
 from decimal import Decimal
-from typing import Iterable, Literal, Optional
+from typing import Iterable, Optional
 
 from babel import Locale, UnknownLocaleError
 from babel.numbers import format_decimal, get_decimal_symbol
+
+from mireport.typealiases import DecimalPlaces
 
 L = logging.getLogger(__name__)
 
@@ -45,8 +47,6 @@ EU_LOCALES = {
     "el-CY",  # Greek (Cyprus)
     "de-AT",  # German (Austria)
 }
-
-DecimalPlaces = int | Literal["INF"]
 
 
 def argparse_locale(s: str) -> Locale:

--- a/src/mireport/typealiases.py
+++ b/src/mireport/typealiases.py
@@ -1,0 +1,5 @@
+from datetime import date, datetime
+from typing import Literal
+
+DecimalPlaces = int | Literal["INF"]
+FactValue = int | float | bool | str | date | datetime

--- a/src/mireport/xbrlreport.py
+++ b/src/mireport/xbrlreport.py
@@ -37,10 +37,9 @@ from mireport.taxonomy import (
     Relationship,
     Taxonomy,
 )
+from mireport.typealiases import DecimalPlaces, FactValue
 
 L = logging.getLogger(__name__)
-
-_FactValue = int | float | bool | str | date | datetime
 
 UNCONSTRAINED_REPORT_PACKAGE_JSON = """{
     "documentInfo": {
@@ -154,12 +153,12 @@ class Fact:
     def __init__(
         self,
         concept: Concept,
-        value: _FactValue,
+        value: FactValue,
         report: "InlineReport",
         aspects: dict[str | QName, str | QName] | None = None,
     ):
         self.concept: Concept = concept
-        self.value: _FactValue = value
+        self.value: FactValue = value
         self._report = report
         self._aspects: dict[str | QName, str | QName] = {}
         if aspects is not None:
@@ -170,6 +169,16 @@ class Fact:
                 if keyConcept.isTypedDimension:
                     dimvalue = self._aspects.pop(key)
                     self._aspects[f"typed {keyConcept.qname}"] = dimvalue
+
+        self._decimals : Optional[DecimalPlaces]
+        if aspect_value := str(self._aspects.get("decimals", "")):
+            if aspect_value == "INF":
+                self._decimals = "INF"
+            else:
+                self._decimals = int(aspect_value)
+            self._aspects["decimals"] = f'"{aspect_value}"'
+        else:
+            self._decimals = None
 
     def __repr__(self) -> str:
         return (
@@ -183,7 +192,7 @@ class Fact:
 
     def __key(
         self,
-    ) -> tuple[QName, _FactValue, frozenset[tuple[str | QName, str | QName]]]:
+    ) -> tuple[QName, FactValue, frozenset[tuple[str | QName, str | QName]]]:
         aspects_flattened = frozenset((k, v) for k, v in self.aspects.items())
         return (self.concept.qname, self.value, aspects_flattened)
 
@@ -207,8 +216,11 @@ class Fact:
             else:
                 output = escape(v)
         else:
+            decimal_places: DecimalPlaces = (
+                self._decimals
+                or "INF"
+            )
             locale = self._report._outputLocale
-            decimal_places = int(str(self.aspects["decimals"])[1:-1])
             try:
                 match self.value:
                     case bool():
@@ -353,7 +365,7 @@ class FactBuilder:
         self._report: InlineReport = report
         self._concept: Optional[Concept] = None
         self._aspects: dict[str | QName, str | QName] = {}
-        self._value: Optional[_FactValue] = None
+        self._value: Optional[FactValue] = None
         self._percentage = False
 
     def __repr__(self) -> str:
@@ -370,7 +382,7 @@ class FactBuilder:
         return self
 
     def setTypedDimension(
-        self, typedDimension: Concept, typedDimensionValue: _FactValue
+        self, typedDimension: Concept, typedDimensionValue: FactValue
     ) -> Self:
         assert typedDimension.isTypedDimension, (
             f"Concept {typedDimension=} is not a typed dimension."
@@ -390,14 +402,18 @@ class FactBuilder:
         if value is None:
             raise InlineReportException("Fact value cannot be None.")
 
-        if not isinstance(value, _FactValue):
+        if not isinstance(value, FactValue):
             value = str(value)
 
         self._value = value
         return self
 
     def setPercentageValue(
-        self, value: int | float, decimals: int, *, inputIsDecimalForm: bool = True
+        self,
+        value: int | float,
+        decimals: DecimalPlaces,
+        *,
+        inputIsDecimalForm: bool = True,
     ) -> Self:
         """Use instead of setValue() when you don't want to think about what to
         do with percentage values.
@@ -415,7 +431,8 @@ class FactBuilder:
             )
             # XBRL stores same way as Excel (100% stored as "1.0")
             self.setScale(-2)
-            decimals += 2
+            if decimals != "INF":
+                decimals += 2
             self.setDecimals(decimals)
         else:
             self.setValue(
@@ -424,8 +441,8 @@ class FactBuilder:
             self.setDecimals(decimals)
         return self
 
-    def setDecimals(self, decimals: int) -> Self:
-        self._aspects["decimals"] = f'"{decimals}"'
+    def setDecimals(self, decimals: DecimalPlaces) -> Self:
+        self._aspects["decimals"] = f'{decimals}'
         return self
 
     def setScale(self, scale: int) -> Self:
@@ -714,7 +731,7 @@ class InlineReport:
 
         self._defaultAspects: dict[str, str] = {
             "numeric-transform": numeric_transform,
-            "decimals": '"0"',
+            "decimals": 'INF',
         }
 
     def setReportTitle(self, title: str) -> None:
@@ -739,7 +756,7 @@ class InlineReport:
                 raise InlineReportException(
                     f"Default aspects not configured correctly. Specifically: '{key=}' '{value=}'"
                 )
-            if key in {"entity-identifier", "entity-scheme"}:
+            if key in {"entity-identifier", "entity-scheme", "decimals"}:
                 value = f'"{value}"'
             aoix.append(f"{{{{ default {key} = {value} }}}}")
         return "\n".join(aoix)

--- a/tests/unitTests/test_localise.py
+++ b/tests/unitTests/test_localise.py
@@ -1,0 +1,94 @@
+from decimal import Decimal
+
+import pytest
+from babel.core import Locale
+
+from mireport.localise import localise_and_format_number  # adjust import as needed
+
+
+@pytest.mark.parametrize(
+    "number,decimal_places,expected",
+    [
+        # Finite decimal places, ROUND_HALF_EVEN
+        (1234.5678, 2, "1,234.57"),  # normal rounding
+        (1234.5, 0, "1,234"),  # 1234.5 rounds down to even
+        (1235.5, 0, "1,236"),  # 1235.5 rounds up to even
+        (Decimal("2.345"), 2, "2.34"),
+        (Decimal("2.355"), 2, "2.36"),
+        (-1234.5, 0, "-1,234"),
+        (-1235.5, 0, "-1,236"),
+    ],
+)
+def test_finite_decimal_places_no_locale(number, decimal_places, expected):
+    assert localise_and_format_number(number, decimal_places) == expected
+
+
+@pytest.mark.parametrize(
+    "number,expected",
+    [
+        # INF facts: preserve all digits, no rounding, no trimming
+        (1234.5678, "1,234.5678"),
+        (Decimal("1234.5678900"), "1,234.5678900"),
+        ("1234.5678900", "1,234.5678900"),
+        (1234, "1,234"),  # integer
+        (Decimal("1234"), "1,234"),
+        (0.000123, "0.000123"),
+        ("1e-6", "0.000001"),  # scientific notation expanded
+        (Decimal("1e-6"), "0.000001"),
+        (-1200.0, "-1,200.0"),  # negative integer as float
+    ],
+)
+def test_inf_no_locale(number, expected):
+    assert localise_and_format_number(number, "INF") == expected
+
+
+@pytest.mark.parametrize(
+    "number,decimal_places,expected",
+    [
+        # Finite decimal places with locale (en_US)
+        (1234.5678, 2, "1,234.57"),
+        (1234.5, 0, "1,234"),
+        (1235.5, 0, "1,236"),
+        (-1234.5, 0, "-1,234"),
+    ],
+)
+def test_finite_decimal_places_with_locale(number, decimal_places, expected):
+    result = localise_and_format_number(
+        number, decimal_places, locale=Locale("en", "US")
+    )
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "number,expected",
+    [
+        # INF with locale (preserve digits exactly)
+        (1234.5678, "1,234.5678"),
+        pytest.param(
+            Decimal("1234.5678900"),
+            "1,234.5678900",
+            marks=pytest.mark.xfail(
+                reason="Trailing zeros are truncated unexpectedly by babel"
+            ),
+        ),
+        ("1e-6", "0.000001"),
+        (-1200.0, "-1,200"),
+    ],
+)
+def test_inf_with_locale(number, expected):
+    result = localise_and_format_number(number, "INF", locale=Locale("en", "US"))
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "invalid_input",
+    [
+        None,
+        [],
+        {},
+        object(),
+    ],
+)
+def test_invalid_types(invalid_input):
+    with pytest.raises(TypeError):
+        localise_and_format_number(invalid_input, 2)


### PR DESCRIPTION
- Update number formatting code to support both an int value for decimal_places and 'INF'.
- Add type alias `DecimalPlaces` to make clear decimals is either an int or 'INF'
- Add unit tests for `localise.localise_and_format_number()`
- 'INF' is now the default value (previously 0) for decimals unless set explicitly to something else

Also introduces `localise.getBestSupportedLanguage()` (which was meant to be in a different pull request but it stands alone fine here so no matter)