### PR TITLE
Remove copyright section from basic output template

### DIFF
--- a/src/mireport/inline_report_templates/inline-report-flat-list.html.jinja
+++ b/src/mireport/inline_report_templates/inline-report-flat-list.html.jinja
@@ -46,10 +46,7 @@
         </div>
         <!-- Final Page -->
         <div class="page footer-page">
-            <p>This report contains {{ ns.fact_count }} XBRL facts ({{ facts | count }} unique facts).</p>
-            <div class="copyright">
-            &#169; 2025 {{ reportInfo.entityName | e }}.
-            </div>
+            <p>This report contains {{ ns.fact_count }} XBRL facts (generated from {{ uniqueFactCount }} unique input facts).</p>
         </div>
     </body>
 </html>


### PR DESCRIPTION
We don't need a copyright section on the simple template so remove it.