### PR TITLE
Enhance migration checker and improve error messaging

### DIFF
--- a/src/mireport/excelprocessor.py
+++ b/src/mireport/excelprocessor.py
@@ -507,7 +507,7 @@ class ExcelProcessor:
         template_validation_fail_name = "template_label_incomplete"
 
         validation_failed_expected_value = self.getSingleStringValue(
-            template_validation_fail_name
+            template_validation_fail_name, fallbackValue="INCOMPLETE"
         )
         validation_status = self.getSingleStringValue(template_validation_name)
         is_incomplete = bool(
@@ -803,9 +803,10 @@ class ExcelProcessor:
         *,
         row: int = -1,
         column: int = -1,
+        fallbackValue: str = "",
     ) -> str:
         value = self.getSingleValue(definedName, row=row, column=column)
-        return str(value) if value is not None else ""
+        return str(value) if value is not None else str(fallbackValue)
 
     def getSimpleUnit(
         self, unitHolder: CellAndXBRLMetadataHolder, cell: CellType

--- a/src/mireport/webapp/migration.py
+++ b/src/mireport/webapp/migration.py
@@ -87,10 +87,13 @@ def checkMigration(conversion: dict) -> Response | None:
                 )
             )
         case MigrationOutcome.INVALID:
-            flash("Report validation is not complete", "error")
+            flash(
+                "Digital template contains validation issues. These must be resolved before uploading.",
+                "error",
+            )
             response = make_response(redirect(url_for("basic.index")))
         case MigrationOutcome.MISSING:
-            flash("Report missing for migration", "error")
+            flash("The uploaded file is not recognised as a valid digital template.", "error")
             response = make_response(redirect(url_for("basic.index")))
         case MigrationOutcome.MIGRATION_OPTIONAL:
             pass  # Continue with conversion

--- a/src/mireport/webapp/migration.py
+++ b/src/mireport/webapp/migration.py
@@ -97,7 +97,10 @@ def checkMigration(conversion: dict) -> Response | None:
             )
             response = make_response(redirect(url_for("basic.index")))
         case MigrationOutcome.MISSING:
-            flash("The uploaded file is not recognised as a valid digital template.", "error")
+            flash(
+                "The uploaded file is not recognised as a valid digital template.",
+                "error",
+            )
             response = make_response(redirect(url_for("basic.index")))
         case MigrationOutcome.MIGRATION_OPTIONAL:
             pass  # Continue with conversion

--- a/src/mireport/webapp/migration.py
+++ b/src/mireport/webapp/migration.py
@@ -58,18 +58,22 @@ def doMigrationChecks(conversion: dict) -> tuple[MigrationOutcome, str]:
         )  # can't do anything if we can't read the report
     elif check_results.version_is_same:
         return MigrationOutcome.SUCCESS, version  # up-to-date version
-    elif check_results.validation_is_incomplete:
-        return MigrationOutcome.INVALID, version  # invalid report, can't proceed
     elif check_results.version_major_minor_same:
         return (
             MigrationOutcome.MIGRATION_OPTIONAL,
             version,
         )  # optional migration offered
     else:
-        return (
-            MigrationOutcome.MIGRATION_REQUIRED,
-            version,
-        )  # older (major) version, must migrate
+        # Definitely an old report that we want to force migrate to the latest version
+        if check_results.validation_is_incomplete:
+            # invalid report, migration cannot proceed.
+            return MigrationOutcome.INVALID, version
+        else:
+            # older (major) version, must migrate
+            return (
+                MigrationOutcome.MIGRATION_REQUIRED,
+                version,
+            )
 
 
 def checkMigration(conversion: dict) -> Response | None:


### PR DESCRIPTION
- Make sure we detect the older (v1.0.x) templates that say they are "INCOMPLETE" slightly differently to the newer ones.
- Improve the error messages from the migration checker
- Only block processing of INCOMPLETE files if we need to migrate them, otherwise let the converter handle them (it produces a warning but otherwise proceeds)