### PR TITLE
Replace `LogToXmlHandler` usage

### DIFF
--- a/scripts/check-report.py
+++ b/scripts/check-report.py
@@ -5,7 +5,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
-import rich
+import rich.traceback
 from rich import print as rich_print
 from rich.logging import RichHandler
 

--- a/src/mireport/arelle/report_info.py
+++ b/src/mireport/arelle/report_info.py
@@ -10,7 +10,6 @@ from typing import BinaryIO, Optional
 from arelle import PackageManager, PluginManager
 from arelle.api.Session import Session
 from arelle.CntlrCmdLine import RuntimeOptions
-from arelle.logging.handlers.LogToXmlHandler import LogToXmlHandler
 
 from mireport.arelle.support import (
     ArelleProcessingResult,
@@ -94,17 +93,15 @@ class ArelleReportProcessor:
                     pass
                 with (
                     Session() as session,
-                    closing(LogToXmlHandler()) as logHandler,
                     reportPackage.fileLike() as requestZipStream,
                 ):
                     session.run(
                         options,
                         sourceZipStream=requestZipStream,
                         responseZipStream=responseZipStream,
-                        logHandler=logHandler,
                         logFilters=[],
                     )
-                    result = ArelleProcessingResult.fromLogToXmlHandler(logHandler)
+                    result = ArelleProcessingResult.fromSession(session)
                 assert requestZipStream.closed, "Forgot to close the stream."
                 return result
             except Exception as arelle_exception:
@@ -125,6 +122,7 @@ class ArelleReportProcessor:
         validationOptions = RuntimeOptions(
             internetConnectivity="offline" if self.workOffline is True else "online",
             keepOpen=True,
+            logFile="logToBuffer",
             logFormat="%(asctime)s [%(messageCode)s] %(message)s - %(file)s",
             logPropagate=False,
             packages=[str(t) for t in self.taxonomyPackages],
@@ -149,6 +147,7 @@ class ArelleReportProcessor:
         jsonOptions = RuntimeOptions(
             internetConnectivity="offline" if self.workOffline else "online",
             keepOpen=True,
+            logFile="logToBuffer",
             logFormat="%(asctime)s [%(messageCode)s] %(message)s - %(file)s",
             logPropagate=False,
             packages=[str(t) for t in self.taxonomyPackages],
@@ -204,6 +203,7 @@ class ArelleReportProcessor:
         viewerOptions = RuntimeOptions(
             internetConnectivity="offline" if self.workOffline else "online",
             keepOpen=True,
+            logFile="logToBuffer",
             logFormat="%(asctime)s [%(messageCode)s] %(message)s - %(file)s",
             logPropagate=False,
             packages=[str(t) for t in self.taxonomyPackages],

--- a/src/mireport/arelle/report_info.py
+++ b/src/mireport/arelle/report_info.py
@@ -1,7 +1,6 @@
 import logging
 import threading
 import zipfile
-from contextlib import closing
 from importlib.metadata import PackageNotFoundError, metadata, version
 from io import BytesIO
 from pathlib import Path, PurePath

--- a/src/mireport/arelle/support.py
+++ b/src/mireport/arelle/support.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping, MutableMapping
 from dataclasses import dataclass
 from typing import Any, Optional, Self
 
-from arelle.logging.handlers.LogToXmlHandler import LogToXmlHandler
+from arelle.api.Session import Session
 from arelle.ModelValue import QName
 from arelle.ModelXbrl import ModelXbrl
 
@@ -107,10 +107,10 @@ class ArelleProcessingResult:
                     )
 
     @classmethod
-    def fromLogToXmlHandler(cls, logHandler: LogToXmlHandler) -> Self:
-        json = logHandler.getJson(clearLogBuffer=False)
-        logLines = logHandler.getLines(clearLogBuffer=False)
-        logHandler.clearLogBuffer()
+    def fromSession(cls, session: Session) -> Self:
+        json = session.get_logs("json", clear_logs=False)
+        text = session.get_logs("text", clear_logs=True)
+        logLines = text.split("\n")
         return cls(json, logLines)
 
     @property

--- a/src/mireport/arelle/taxonomy_info.py
+++ b/src/mireport/arelle/taxonomy_info.py
@@ -3,7 +3,6 @@ import logging
 import time
 from collections import defaultdict
 from collections.abc import Iterable, MutableMapping
-from contextlib import closing
 from typing import Any, Optional, TypeVar
 
 from arelle import XbrlConst

--- a/src/mireport/arelle/taxonomy_info.py
+++ b/src/mireport/arelle/taxonomy_info.py
@@ -9,7 +9,6 @@ from typing import Any, Optional, TypeVar
 from arelle import XbrlConst
 from arelle.api.Session import Session
 from arelle.Cntlr import Cntlr
-from arelle.logging.handlers.LogToXmlHandler import LogToXmlHandler
 from arelle.ModelDtsObject import ModelConcept, ModelResource, ModelRoleType
 from arelle.ModelRelationshipSet import ModelRelationshipSet
 from arelle.ModelValue import QName
@@ -71,6 +70,7 @@ def callArelleForTaxonomyInfo(
         internetConnectivity="offline",
         formulaAction="none",
         keepOpen=False,
+        logFile="logToBuffer",
         logFormat="%(asctime)s [%(messageCode)s] %(message)s - %(file)s",
         logPropagate=False,
         packages=taxonomy_zips,
@@ -79,13 +79,12 @@ def callArelleForTaxonomyInfo(
         validate=True,
         utrValidate=utrValidation,
     )
-    with Session() as session, closing(LogToXmlHandler()) as log_handler:
+    with Session() as session:
         session.run(
             options,
-            logHandler=log_handler,
             logFilters=[],
         )
-        results = ArelleProcessingResult.fromLogToXmlHandler(log_handler)
+        results = ArelleProcessingResult.fromSession(session)
     return results
 
 


### PR DESCRIPTION
[Related Arelle issue
](https://github.com/Arelle/Arelle/issues/2305)

Consumers of Arelle generally should not need to manage the lifecycle of Arelle's log handlers. These log handlers are public API by convention but not something we intend to support going forward. 

The Session API provides `get_logs` for accessing logs in various formats (although an analogous option for `getLines` does not exist, hopefully splitting the full text on newlines is sufficient).

> [!NOTE]
> Not exactly sure why `rich.traceback` import change was necessary (possibly something related to the release of version 15), but since it seems like a logical change and was causing integration test failures, I've included the change in this PR. 