### PR TITLE
Hoist inconsistent-duplicate detection and add fact provenance

### DIFF
--- a/scripts/parse-and-dump.py
+++ b/scripts/parse-and-dump.py
@@ -119,7 +119,7 @@ def main() -> None:
     start = time.perf_counter_ns()
     excel_file = Path(args.excel)
     checkExcelFilePath(excel_file)
-    with closing(loadExcelFromPathOrFileLike(excel_file)) as wb:
+    with closing(loadExcelFromPathOrFileLike(excel_file, read_only=True)) as wb:
         if args.verbose:
             print(f"Opened {excel_file}")
             print("Found sheets:", *wb.sheetnames, sep="\n\t")

--- a/src/mireport/report/fact.py
+++ b/src/mireport/report/fact.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from enum import StrEnum
-from typing import TYPE_CHECKING, NamedTuple, cast
+from typing import TYPE_CHECKING, NamedTuple, Protocol, cast, runtime_checkable
 
 from markupsafe import Markup, escape
 
@@ -48,6 +48,18 @@ class Symbol(NamedTuple):
     name: str
 
 
+@runtime_checkable
+class Provenance(Protocol):
+    """
+    Describes where a Fact came from (e.g. a source cell reference).
+
+    The report package is source-agnostic, so callers supply any object whose
+    ``__str__`` yields a human-readable location. A plain ``str`` satisfies this.
+    """
+
+    def __str__(self) -> str: ...
+
+
 class Fact:
     """
     Represents a fact in an XBRL instance document.
@@ -59,9 +71,11 @@ class Fact:
         value: FactValue,
         report: InlineReport,
         aspects: dict[str | QName, str | QName] | None = None,
+        provenance: Provenance | None = None,
     ):
         self.concept: Concept = concept
         self.value: FactValue = value
+        self.provenance: Provenance | None = provenance
         self._report = report
         self._aspects: dict[str | QName, str | QName] = {}
         if aspects is not None:

--- a/src/mireport/report/factbuilder.py
+++ b/src/mireport/report/factbuilder.py
@@ -4,7 +4,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from mireport.exceptions import InlineReportException
-from mireport.report.fact import Fact
+from mireport.report.fact import Fact, Provenance
 from mireport.stringutil import xml_clean
 from mireport.taxonomy import Concept, QName, Taxonomy
 from mireport.typealiases import DecimalPlaces, FactValue
@@ -28,6 +28,7 @@ class FactBuilder:
         self._concept: Concept | None = None
         self._aspects: dict[str | QName, str | QName] = {}
         self._value: FactValue | None = None
+        self._provenance: Provenance | None = None
 
     def __repr__(self) -> str:
         bits = (self._concept, self._aspects, self._value)
@@ -119,6 +120,11 @@ class FactBuilder:
         if not value.startswith('"') and not value.endswith('"'):
             value = f'"{value}"'
         self._aspects["hidden-value"] = value
+        return self
+
+    def setProvenance(self, provenance: Provenance) -> Self:
+        """Record where this fact originated (e.g. a source cell reference)."""
+        self._provenance = provenance
         return self
 
     def setConcept(self, concept: Concept) -> Self:
@@ -360,4 +366,10 @@ class FactBuilder:
 
         self.validateTaxonomyDimensions()
         # TODO: check aspect validity before creating fact and raise Exception if invalid
-        return Fact(self._concept, self._value, self._report, self._aspects)
+        return Fact(
+            self._concept,
+            self._value,
+            self._report,
+            self._aspects,
+            self._provenance,
+        )

--- a/src/mireport/report/inlinereport.py
+++ b/src/mireport/report/inlinereport.py
@@ -7,7 +7,11 @@ from collections import defaultdict
 from datetime import UTC, date, datetime
 from io import BytesIO
 from itertools import count
+from typing import TYPE_CHECKING, Protocol
 from unicodedata import name as unicode_name
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 import ixbrltemplates
 from babel import Locale
@@ -48,6 +52,15 @@ INLINE_REPORT_PACKAGE_JSON = b"""{
         "documentType": "https://xbrl.org/report-package/2023/xbri"
     }
 }"""
+
+
+class InconsistentDuplicateHandler(Protocol):
+    """
+    Callback invoked once per set of inconsistent duplicate facts (facts sharing
+    a concept and all aspects but holding different values).
+    """
+
+    def __call__(self, concept: Concept, facts: Sequence[Fact]) -> None: ...
 
 
 class InlineReport:
@@ -199,6 +212,27 @@ class InlineReport:
         """
         self._facts.append(fact)
         self._factsByConcept[fact.concept].append(fact)
+
+    def reportInconsistentDuplicateFacts(
+        self, handler: InconsistentDuplicateHandler
+    ) -> None:
+        """
+        Find inconsistent duplicate facts and report each set via handler.
+
+        Facts are inconsistent duplicates when they share a concept and all
+        aspects (dimensions, period, unit, ...) but hold different values. Such
+        facts cannot both be rendered, so one is silently dropped downstream;
+        this surfaces the conflict so the caller can warn the report preparer.
+        """
+        for concept, facts in self._factsByConcept.items():
+            if len(facts) < 2:
+                continue
+            byAspects: dict[frozenset[tuple], list[Fact]] = defaultdict(list)
+            for fact in facts:
+                byAspects[frozenset(fact.aspects.items())].append(fact)
+            for group in byAspects.values():
+                if len({fact.value for fact in group}) > 1:
+                    handler(concept, group)
 
     def _createFootnote(self, content: Markup) -> Footnote:
         fn = Footnote(id=next(self._footnoteCounter), content=content)

--- a/src/mireport/report/layout.py
+++ b/src/mireport/report/layout.py
@@ -364,7 +364,10 @@ class ReportLayoutOrganiser:
                 processed.add(u)
                 processed.update(inconsistent_duplicates)
                 if inconsistent_duplicates:
-                    L.warning(
+                    # Surfaced to the report preparer as an error via
+                    # InlineReport.reportInconsistentDuplicateFacts; kept here at
+                    # debug level only as a developer safety net.
+                    L.debug(
                         f"Fact has inconsistent duplicates.\nUnused: {u}\nOthers: {inconsistent_duplicates}"
                     )
 

--- a/src/mireport/xlsx_template_reader/processor.py
+++ b/src/mireport/xlsx_template_reader/processor.py
@@ -4,7 +4,7 @@ import difflib
 import logging
 import re
 from collections import defaultdict
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime
 from functools import lru_cache
@@ -144,6 +144,9 @@ class CellRangeMetadata:
     effectiveHeight: int
     cellsPopulated: int
 
+    def __str__(self) -> str:
+        return excelCellRangeRef(self.worksheet, self.cellRange)
+
     def contains(self, other: CellRangeMetadata) -> bool:
         """True if other is on the same worksheet and fully within this range."""
         return self.worksheet is other.worksheet and self.cellRange.issuperset(
@@ -257,6 +260,9 @@ class ExcelProcessor:
             self._createNamedPeriods()
             self.createSimpleFacts()
             self.createTableFacts()
+            self._report.reportInconsistentDuplicateFacts(
+                self._reportInconsistentDuplicateFacts
+            )
             self._processFootnotes()
             self.checkForUnhandledItems()
             return self._report
@@ -1444,6 +1450,7 @@ class ExcelProcessor:
         self, factBuilder: FactBuilder, holder: CellAndXBRLMetadataHolder
     ) -> bool:
         try:
+            factBuilder.setProvenance(holder)
             self._report.addFact(factBuilder.buildFact())
             return True
         except InlineReportException as i:
@@ -1454,6 +1461,33 @@ class ExcelProcessor:
                 excel_reference=excelCellRangeRef(holder.worksheet, holder.cellRange),
             )
         return False
+
+    def _reportInconsistentDuplicateFacts(
+        self, concept: Concept, facts: Sequence[Fact]
+    ) -> None:
+        """Surface inconsistent duplicate facts to the report preparer as an error.
+
+        These are facts with the same concept and dimensions but different values
+        (e.g. the same waste type appearing twice with different amounts). Only one
+        value can be rendered, so the conflict must be fixed in the template."""
+        details = "; ".join(
+            f"'{fact.value}' ({fact.provenance})"
+            if fact.provenance is not None
+            else f"'{fact.value}'"
+            for fact in facts
+        )
+        first_provenance = next(
+            (str(fact.provenance) for fact in facts if fact.provenance is not None),
+            None,
+        )
+        self._results.addMessage(
+            f"Conflicting duplicate values for {concept.qname} with the same "
+            f"dimensions. Only one will appear in the report. Values: {details}.",
+            Severity.ERROR,
+            MessageType.Conversion,
+            taxonomy_concept=concept,
+            excel_reference=first_provenance,
+        )
 
     def setUnitForName(
         self,

--- a/tests/unitTests/test_inconsistent_duplicates.py
+++ b/tests/unitTests/test_inconsistent_duplicates.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from types import SimpleNamespace
+
+from mireport.report.inlinereport import InlineReport
+
+
+def _fact(concept, value, aspects, provenance=None):
+    return SimpleNamespace(
+        concept=concept, value=value, aspects=aspects, provenance=provenance
+    )
+
+
+def _report_with(facts):
+    """Minimal stand-in exposing only what the method under test touches."""
+    byConcept = defaultdict(list)
+    for f in facts:
+        byConcept[f.concept].append(f)
+    return SimpleNamespace(_factsByConcept=byConcept)
+
+
+def _collect(report):
+    conflicts = []
+    InlineReport.reportInconsistentDuplicateFacts(
+        report, lambda concept, facts: conflicts.append((concept, list(facts)))
+    )
+    return conflicts
+
+
+def test_inconsistent_duplicates_are_reported():
+    aspects = {"dim": "memberA"}
+    facts = [
+        _fact("conceptA", "250", aspects, provenance="Sheet1!$B$2"),
+        _fact("conceptA", "310", aspects, provenance="Sheet1!$B$3"),
+    ]
+    conflicts = _collect(_report_with(facts))
+
+    assert len(conflicts) == 1
+    concept, group = conflicts[0]
+    assert concept == "conceptA"
+    assert {f.value for f in group} == {"250", "310"}
+
+
+def test_identical_duplicates_are_not_reported():
+    aspects = {"dim": "memberA"}
+    facts = [
+        _fact("conceptA", "250", aspects),
+        _fact("conceptA", "250", aspects),
+    ]
+    assert _collect(_report_with(facts)) == []
+
+
+def test_same_value_different_dimensions_is_not_a_conflict():
+    facts = [
+        _fact("conceptA", "250", {"dim": "memberA"}),
+        _fact("conceptA", "310", {"dim": "memberB"}),
+    ]
+    assert _collect(_report_with(facts)) == []
+
+
+def test_single_fact_per_concept_is_not_a_conflict():
+    facts = [
+        _fact("conceptA", "250", {"dim": "memberA"}),
+        _fact("conceptB", "310", {"dim": "memberA"}),
+    ]
+    assert _collect(_report_with(facts)) == []

--- a/tests/unitTests/test_layout.py
+++ b/tests/unitTests/test_layout.py
@@ -388,7 +388,10 @@ class TestCheckAllFactsUsed:
         o.report.getFacts.return_value = [unused]
         o.checkAllFactsUsed()  # must not raise
 
-    def test_unused_fact_with_inconsistent_duplicate_logs_warning(self, caplog):
+    def test_unused_fact_with_inconsistent_duplicate_logs_debug(self, caplog):
+        # User-facing surfacing now happens via
+        # InlineReport.reportInconsistentDuplicateFacts; this is kept only as a
+        # debug-level developer safety net.
         concept = MagicMock(spec=Concept)
         aspects_dict = {"period": "2024"}
         unused = _fact(value="v1", concept=concept, aspects=aspects_dict)
@@ -396,7 +399,7 @@ class TestCheckAllFactsUsed:
         o = _organiser(facts_by_concept={concept: [unused, duplicate]})
         o.reportSections = []
         o.report.getFacts.return_value = [unused, duplicate]
-        with caplog.at_level(logging.WARNING, logger="mireport.report.layout"):
+        with caplog.at_level(logging.DEBUG, logger="mireport.report.layout"):
             o.checkAllFactsUsed()
         assert any("inconsistent" in r.message.lower() for r in caplog.records)
 


### PR DESCRIPTION
Centralise inconsistent-duplicate handling across factbuilder/inlinereport/
processor with fact provenance; add test_inconsistent_duplicates.py.
