### PR TITLE
Full semver version handling + migration/template tweaks

### DIFF
--- a/src/digital_converter_webapp/migration.py
+++ b/src/digital_converter_webapp/migration.py
@@ -22,7 +22,7 @@ try:
     MIGRATION_WORKING = True
 except ImportError:
     logging.getLogger(__name__).warning(
-        "Migration tool not available, migration functionality will be disabled"
+        "Migration tool not available, migration functionality will be disabled", exc_info=True
     )
     MIGRATION_WORKING = False
 
@@ -144,17 +144,19 @@ def migrationPage(id: str) -> Response:
         )
         excel = FilelikeAndFileName(*conversion["excel"])
 
-        has_migration_results = "migrated_excel" in conversion
+        has_migration_results = "migrated_excel" in conversion or "migration_error" in conversion
+        migration_error = conversion.get("migration_error")
         return Response(
             render_template(
                 "migration_page.html.jinja",
                 conversion_id=id,
                 filename=excel.filename,
                 version=version,
-                newest_version=OUR_VERSION_HOLDER,
+                newest_version=OUR_VERSION_HOLDER.strip_build_metadata,
                 has_migration_results=has_migration_results,
                 elapsed=conversion.get("migration_elapsed"),
                 migration_issues=conversion.get("migration_issues", []),
+                migration_error=migration_error,
             )
         )
     except Exception as e:
@@ -179,23 +181,33 @@ def migrationButton(id: str) -> Response:
             return make_response(jsonify({"error": "No file found in session"}), 400)
 
         original_excel = FilelikeAndFileName(*conversion["excel"])
-        migrated_bytes, elapsed, migration_issues = migrate_workbook_as_bytes(
-            original_excel.fileLike()
-        )
+
+        # Clear any stale error from a previous failed attempt
+        conversion.pop("migration_error", None)
+        conversion.pop("migrated_excel", None)
+
+        try:
+            migrated_bytes, elapsed, migration_issues = migrate_workbook_as_bytes(
+                original_excel.fileLike()
+            )
+        except NotImplementedError:
+            L.error("Migration tool not available for id=%s", id)
+            flash("Migration functionality is not available on this server.", "error")
+            return make_response(redirect(url_for("basic.index")))
+        except Exception as e:
+            L.exception("Migration failed for id=%s", id)
+            conversion["migration_error"] = f"Migration failed: {e}"
+            conversion["migration_elapsed"] = None
+            session.modified = True
+            return make_response(redirect(url_for("basic.migrationPage", id=id), code=303))
+
         o_path = PurePath(original_excel.filename)
         m_name = o_path.with_stem(f"{o_path.stem}_migrated_to_latest_version").name
         migrated_excel = FilelikeAndFileName(
             fileContent=migrated_bytes, filename=m_name
         )
 
-        # Guard against empty output
-        size = len(migrated_excel.fileContent)
-        L.info("MigrationButton: generated workbook size=%d bytes for id=%s", size, id)
-        if not size:
-            L.error("MigrationButton: empty workbook output for id=%s", id)
-            return make_response(
-                jsonify({"error": "Migration produced empty file"}), 500
-            )
+        L.info("MigrationButton: generated workbook size=%d bytes for id=%s", len(migrated_bytes), id)
 
         # Store migrated file and results in session, then redirect to results view
         conversion["migrated_excel"] = migrated_excel
@@ -206,8 +218,9 @@ def migrationButton(id: str) -> Response:
         return make_response(redirect(url_for("basic.migrationPage", id=id), code=303))
 
     except Exception as e:
-        L.exception("Exception during migration", exc_info=e)
-        return make_response(jsonify({"error": str(e)}), 500)
+        L.exception("Unexpected error in migrationButton for id=%s", id)
+        flash(f"An unexpected error occurred: {e}", "error")
+        return make_response(redirect(url_for("basic.index")))
 
 
 @convert_bp.route("/downloadMigrated/<id>", methods=["GET", "HEAD"])

--- a/src/digital_converter_webapp/migration.py
+++ b/src/digital_converter_webapp/migration.py
@@ -22,7 +22,8 @@ try:
     MIGRATION_WORKING = True
 except ImportError:
     logging.getLogger(__name__).warning(
-        "Migration tool not available, migration functionality will be disabled", exc_info=True
+        "Migration tool not available, migration functionality will be disabled",
+        exc_info=True,
     )
     MIGRATION_WORKING = False
 
@@ -144,7 +145,9 @@ def migrationPage(id: str) -> Response:
         )
         excel = FilelikeAndFileName(*conversion["excel"])
 
-        has_migration_results = "migrated_excel" in conversion or "migration_error" in conversion
+        has_migration_results = (
+            "migrated_excel" in conversion or "migration_error" in conversion
+        )
         migration_error = conversion.get("migration_error")
         return Response(
             render_template(
@@ -199,7 +202,9 @@ def migrationButton(id: str) -> Response:
             conversion["migration_error"] = f"Migration failed: {e}"
             conversion["migration_elapsed"] = None
             session.modified = True
-            return make_response(redirect(url_for("basic.migrationPage", id=id), code=303))
+            return make_response(
+                redirect(url_for("basic.migrationPage", id=id), code=303)
+            )
 
         o_path = PurePath(original_excel.filename)
         m_name = o_path.with_stem(f"{o_path.stem}_migrated_to_latest_version").name
@@ -207,7 +212,11 @@ def migrationButton(id: str) -> Response:
             fileContent=migrated_bytes, filename=m_name
         )
 
-        L.info("MigrationButton: generated workbook size=%d bytes for id=%s", len(migrated_bytes), id)
+        L.info(
+            "MigrationButton: generated workbook size=%d bytes for id=%s",
+            len(migrated_bytes),
+            id,
+        )
 
         # Store migrated file and results in session, then redirect to results view
         conversion["migrated_excel"] = migrated_excel

--- a/src/digital_converter_webapp/templates/base.html.jinja
+++ b/src/digital_converter_webapp/templates/base.html.jinja
@@ -21,6 +21,16 @@
 
       <!-- Title -->
       <h1 class="text-2xl font-bold text-center text-gray-800">VSME Digital Template to XBRL Converter</h1>
+
+      {% with messages = get_flashed_messages(with_categories=true) %}
+      {% for category, message in messages %}
+      {% set palette = {'error': 'bg-red-100 border-red-400 text-red-700', 'success': 'bg-green-100 border-green-400 text-green-700'}.get(category, 'bg-gray-100 border-gray-400 text-gray-700') %}
+      <div class="{{ palette }} border px-4 py-3 rounded" role="alert">
+        <span class="block sm:inline">{{ message }}</span>
+      </div>
+      {% endfor %}
+      {% endwith %}
+
       {% block content %}{% endblock %}
     </div>
   </main>

--- a/src/digital_converter_webapp/templates/excel-to-xbrl-converter.html.jinja
+++ b/src/digital_converter_webapp/templates/excel-to-xbrl-converter.html.jinja
@@ -17,20 +17,6 @@
   </ol>
 </div>
 
-<!-- Flash Error Messages -->
-{% with messages = get_flashed_messages(with_categories=true) %}
-  {% if messages %}
-    {% for category, message in messages %}
-      {% if category == 'error' %}
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
-          <span class="block sm:inline">{{ message }}</span>
-        </div>
-      {% endif %}
-    {% endfor %}
-  {% endif %}
-{% endwith %}
-
-
 <!-- Upload Form -->
 <form action="{{ url_for('basic.upload') }}" method="post" enctype="multipart/form-data" class="space-y-4" onsubmit="showSpinner('Converting... Please wait.')">
 

--- a/src/digital_converter_webapp/templates/migration_page.html.jinja
+++ b/src/digital_converter_webapp/templates/migration_page.html.jinja
@@ -3,6 +3,17 @@
 
 {% block title %}VSME Digital Template Migration Tool{% endblock %}
 
+{% macro convert_with_old_version() %}
+<div class="flex justify-center mt-3">
+    <a href="{{ url_for('basic.convert', id=conversion_id, skip_migration=True) }}"
+        onclick="showSpinner('Converting... Please wait.')"
+        class="inline-block px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold text-center rounded-lg transition"
+        style="min-width: 200px;">
+        Convert with old version
+    </a>
+</div>
+{% endmacro %}
+
 {% block content %}
 
 <!-- Back to Home -->
@@ -49,19 +60,6 @@
     </ul>
 </section>
 
-<!-- Flash Messages -->
-{% with messages = get_flashed_messages(with_categories=true) %}
-{% for category, message in messages %}
-{% if category in ('error', 'success') %}
-{% set palette = {'error': 'bg-red-100 border-red-400 text-red-700',
-                  'success': 'bg-green-100 border-green-400 text-green-700'}[category] %}
-<div class="{{ palette }} border px-4 py-3 rounded mb-4" role="alert">
-    <span class="block sm:inline">{{ message }}</span>
-</div>
-{% endif %}
-{% endfor %}
-{% endwith %}
-
 <!-- File Loaded Info -->
 <p class="bg-blue-50 border border-blue-300 rounded-lg p-4 mb-4 text-sm text-blue-800">
     <strong>File loaded:</strong> {{ filename }}
@@ -80,14 +78,18 @@
         </button>
     </div>
 </form>
-<div class="flex justify-center mt-3">
-    <a href="{{ url_for('basic.convert', id=conversion_id, skip_migration=True) }}"
-        onclick="showSpinner('Converting... Please wait.')"
-        class="inline-block px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold text-center rounded-lg transition"
-        style="min-width: 200px;">
-        Convert with old version
-    </a>
-</div>
+{{ convert_with_old_version() }}
+
+{% elif migration_error %}
+
+<!-- Migration failed: show error and allow retry -->
+<section id="migrationResults" class="space-y-4 mb-6" tabindex="-1">
+    <div class="bg-red-50 border border-red-300 rounded-lg p-4">
+        <h3 class="font-semibold text-red-900 mb-2">Migration Failed</h3>
+        <p class="text-sm text-red-800">{{ migration_error | e }}</p>
+    </div>
+</section>
+{{ convert_with_old_version() }}
 
 {% else %}
 
@@ -138,13 +140,8 @@
 
 <div class="flex flex-wrap justify-center items-center gap-4">
     {{ download_button('migrated', url_for('basic.downloadMigrated', id=conversion_id)) }}
-    <a href="{{ url_for('basic.convert', id=conversion_id, skip_migration=True) }}"
-        onclick="showSpinner('Converting... Please wait.')"
-        class="inline-block px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold text-center rounded-lg transition"
-        style="min-width: 200px;">
-        Convert with old version
-    </a>
 </div>
+{{ convert_with_old_version() }}
 
 <script>
     (function () {

--- a/src/mireport/conversionresults.py
+++ b/src/mireport/conversionresults.py
@@ -14,10 +14,19 @@ if TYPE_CHECKING:
     from types import TracebackType
     from typing import Self
 
+from markupsafe import Markup
+
 from mireport.exceptions import EarlyAbortException
-from mireport.stringutil import format_time_ns
+from mireport.stringutil import format_time_ns, str_to_markupsafe
 from mireport.taxonomy import Concept
 from mireport.xml import QName
+
+
+class MessageText(str):
+    """str subclass that renders as HTML-safe (escaped, newlines as <br />) in Jinja2 templates."""
+
+    def __html__(self) -> Markup:
+        return str_to_markupsafe(self)
 
 
 class Severity(StrEnum):
@@ -113,7 +122,7 @@ class Message:
         conceptQName: str | None = None,
         excelReference: str | None = None,
     ):
-        self.messageText: str = messageText
+        self.messageText: MessageText = MessageText(messageText)
         self.severity: Severity = severity
         self.messageType: MessageType = messageType
         self.conceptQName: str | None = conceptQName
@@ -142,7 +151,7 @@ class Message:
 
     def toDict(self) -> dict:
         d = {
-            "m": self.messageText,
+            "m": str(self.messageText),
             "s": self.severity.name,
             "mt": self.messageType.name,
             "c": self.conceptQName,

--- a/src/mireport/version.py
+++ b/src/mireport/version.py
@@ -1,6 +1,20 @@
+from __future__ import annotations
+
+import json
+import logging
 import re
-from importlib.metadata import PackageNotFoundError, version
+import subprocess
+from functools import cache, partial
+from importlib.metadata import Distribution, PackageNotFoundError, version
+from pathlib import Path
 from typing import NamedTuple, Self
+from urllib.parse import urlparse
+from urllib.request import url2pathname
+
+_BUILD_METADATA_SAFE_RE = re.compile(r"[^0-9A-Za-z.-]")
+_PACKAGE_NAME = "EFRAG-DigitalTemplateToXBRL-Converter"
+_VERSION_PARSE_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(.*)$")
+L = logging.getLogger(__name__)
 
 
 class VersionInformationTuple(NamedTuple):
@@ -20,10 +34,64 @@ class VersionHolder(NamedTuple):
     def __str__(self) -> str:
         return f"{self.major}.{self.minor}.{self.patch}{self.suffix}"
 
+    @property
+    def _core(self) -> tuple[int, int, int]:
+        return (self.major, self.minor, self.patch)
+
+    @property
+    def is_prerelease(self) -> bool:
+        return self.suffix.startswith("-")
+
+    @property
+    def prerelease(self) -> str | None:
+        if not self.is_prerelease:
+            return None
+        pre, _, _ = self.suffix[1:].partition("+")
+        return pre or None
+
+    @property
+    def build_metadata(self) -> str | None:
+        _, _, meta = self.suffix.partition("+")
+        return meta or None
+
+    @property
+    def strip_build_metadata(self) -> VersionHolder:
+        pre = f"-{p}" if (p := self.prerelease) else ""
+        return VersionHolder(self.major, self.minor, self.patch, pre)
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, VersionHolder):
+            return NotImplemented
+        if self._core != other._core:
+            return self._core < other._core
+        # semver §11.3: pre-release < release; §10: build metadata ignored for precedence
+        if self.is_prerelease == other.is_prerelease:
+            if self.is_prerelease:
+                return (
+                    self.suffix < other.suffix
+                )  # lexical between pre-release variants
+            return False  # same-core non-pre-release: same precedence per semver §10
+        return self.is_prerelease  # pre-release < release
+
+    def __gt__(self, other: object) -> bool:
+        if not isinstance(other, VersionHolder):
+            return NotImplemented
+        return other < self
+
+    def __le__(self, other: object) -> bool:
+        if not isinstance(other, VersionHolder):
+            return NotImplemented
+        return not (other < self)
+
+    def __ge__(self, other: object) -> bool:
+        if not isinstance(other, VersionHolder):
+            return NotImplemented
+        return not (self < other)
+
     @classmethod
     def parse(cls, version_str: str) -> Self:
         version_str = version_str.strip()
-        match = re.match(r"^(\d+)\.(\d+)\.(\d+)(.*)?$", version_str)
+        match = _VERSION_PARSE_RE.match(version_str)
         if not match:
             raise ValueError(f"Invalid version format: {version_str}")
         major, minor, patch, suffix = match.groups()
@@ -37,9 +105,59 @@ class VersionHolder(NamedTuple):
             return None
 
 
+@cache
+def _editable_suffix() -> str:
+    try:
+        dist = Distribution.from_name(_PACKAGE_NAME)
+        if not (raw := dist.read_text("direct_url.json")):
+            return ""
+        data = json.loads(raw)
+        # https://packaging.python.org/en/latest/specifications/direct-url-data-structure/
+        # editable (type: boolean): true if the distribution was/is to be
+        # installed in editable mode, false otherwise. If absent, default to
+        # false.
+        editable = bool(data.get("dir_info", {}).get("editable", False))
+        if not editable:
+            return ""
+        if (url := data.get("url", "")).startswith("file://"):
+            source_dir = Path(url2pathname(urlparse(url).path))
+            _git = partial(
+                subprocess.run,
+                capture_output=True,
+                stdin=subprocess.DEVNULL,
+                encoding="utf-8",
+                timeout=5,
+                check=True,
+                cwd=source_dir,
+            )
+            result = _git(
+                [
+                    "git",
+                    "-c",
+                    "i18n.logOutputEncoding=utf-8",
+                    "describe",
+                    "--tags",
+                    "--always",
+                    "--dirty=.dirty",
+                ]
+            )
+            output = result.stdout.strip()
+            # Long form "tag-N-ghash[.dirty]" → extract just hash[.dirty]
+            if m := re.match(r"^.+-\d+-g([0-9a-f]+)(\.dirty)?$", output):
+                output = m.group(1) + (m.group(2) or "")
+            return f"+git.{_BUILD_METADATA_SAFE_RE.sub('-', output)}"
+        return ""
+    except Exception:
+        L.warning(
+            "Failed to determine editable version suffix, falling back to no suffix",
+            exc_info=True,
+        )
+    return ""
+
+
 try:
-    OUR_VERSION = version("EFRAG-DigitalTemplateToXBRL-Converter")
+    OUR_VERSION = version(_PACKAGE_NAME) + _editable_suffix()
     OUR_VERSION_HOLDER = VersionHolder.parse(OUR_VERSION)
-except PackageNotFoundError:
+except (PackageNotFoundError, ValueError):
     OUR_VERSION = "(unknown version)"
     OUR_VERSION_HOLDER = VersionHolder(0, 0, 0, "(unknown version)")

--- a/src/mireport/version.py
+++ b/src/mireport/version.py
@@ -116,38 +116,52 @@ def _editable_suffix() -> str:
         # editable (type: boolean): true if the distribution was/is to be
         # installed in editable mode, false otherwise. If absent, default to
         # false.
-        editable = bool(data.get("dir_info", {}).get("editable", False))
-        if not editable:
+        #
+        # N.B. JSON can hold any type, so each field is type checked before use.
+        # That keeps a malformed direct_url.json an early return rather than an
+        # AttributeError we would have to catch (and which would also mask any
+        # genuine typo in this function).
+        if not isinstance(data, dict):
             return ""
-        if (url := data.get("url", "")).startswith("file://"):
-            source_dir = Path(url2pathname(urlparse(url).path))
-            _git = partial(
-                subprocess.run,
-                capture_output=True,
-                stdin=subprocess.DEVNULL,
-                encoding="utf-8",
-                timeout=5,
-                check=True,
-                cwd=source_dir,
-            )
-            result = _git(
-                [
-                    "git",
-                    "-c",
-                    "i18n.logOutputEncoding=utf-8",
-                    "describe",
-                    "--tags",
-                    "--always",
-                    "--dirty=.dirty",
-                ]
-            )
-            output = result.stdout.strip()
-            # Long form "tag-N-ghash[.dirty]" → extract just hash[.dirty]
-            if m := re.match(r"^.+-\d+-g([0-9a-f]+)(\.dirty)?$", output):
-                output = m.group(1) + (m.group(2) or "")
-            return f"+git.{_BUILD_METADATA_SAFE_RE.sub('-', output)}"
-        return ""
-    except Exception:
+        dir_info = data.get("dir_info")
+        if not isinstance(dir_info, dict) or not dir_info.get("editable", False):
+            return ""
+        url = data.get("url")
+        if not (isinstance(url, str) and url.startswith("file://")):
+            return ""
+
+        source_dir = Path(url2pathname(urlparse(url).path))
+        _git = partial(
+            subprocess.run,
+            capture_output=True,
+            stdin=subprocess.DEVNULL,
+            encoding="utf-8",
+            timeout=5,
+            check=True,
+            cwd=source_dir,
+        )
+        result = _git(
+            [
+                "git",
+                "-c",
+                "i18n.logOutputEncoding=utf-8",
+                "describe",
+                "--tags",
+                "--always",
+                "--dirty=.dirty",
+            ]
+        )
+        output = result.stdout.strip()
+        # Long form "tag-N-ghash[.dirty]" → extract just hash[.dirty]
+        if m := re.match(r"^.+-\d+-g([0-9a-f]+)(\.dirty)?$", output):
+            output = m.group(1) + (m.group(2) or "")
+        return f"+git.{_BUILD_METADATA_SAFE_RE.sub('-', output)}"
+    except (
+        PackageNotFoundError,  # we are not installed at all
+        ValueError,  # bad JSON, non-UTF-8 direct_url.json, NUL in path
+        OSError,  # git absent, unreadable cwd, URLError from url2pathname
+        subprocess.SubprocessError,  # git returned non-zero or timed out
+    ):
         L.warning(
             "Failed to determine editable version suffix, falling back to no suffix",
             exc_info=True,

--- a/src/mireport/xlsx_template_reader/_util.py
+++ b/src/mireport/xlsx_template_reader/_util.py
@@ -13,6 +13,7 @@ from typing import (
 
 from openpyxl import Workbook, load_workbook
 from openpyxl.cell import Cell, MergedCell, ReadOnlyCell
+from openpyxl.cell.cell import ERROR_CODES
 from openpyxl.utils.cell import absolute_coordinate, quote_sheetname
 from openpyxl.workbook.defined_name import DefinedName
 from openpyxl.worksheet.cell_range import CellRange
@@ -25,6 +26,16 @@ CellType: TypeAlias = ReadOnlyCell | MergedCell | Cell
 CellValueType: TypeAlias = bool | float | int | str | datetime | date | time | None
 
 EXCEL_PLACEHOLDER_VALUE = "#VALUE!"
+
+
+# openpyxl's ERROR_CODES covers standard Excel errors; #ERROR! is a Google Sheets addition
+EXCEL_ERROR_VALUES: frozenset[str] = frozenset(ERROR_CODES)
+GOOGLE_SHEET_ERROR_VALUES: frozenset[str] = frozenset({"#ERROR!"})
+ALL_ERROR_VALUES: frozenset[str] = EXCEL_ERROR_VALUES.union(GOOGLE_SHEET_ERROR_VALUES)
+
+
+def is_error_value(v: str) -> bool:
+    return v in ALL_ERROR_VALUES
 
 
 class NamedRangeException(OpenPyXlRelatedException):

--- a/src/mireport/xlsx_template_reader/processor.py
+++ b/src/mireport/xlsx_template_reader/processor.py
@@ -61,6 +61,7 @@ from mireport.xlsx_template_reader._util import (
     get_decimal_places,
     getCellRangeIterator,
     getEffectiveCellRangeDimensions,
+    is_error_value,
     loadExcelFromPathOrFileLike,
 )
 
@@ -68,7 +69,10 @@ L = logging.getLogger(__name__)
 
 EE_SET_DESIRED_EMPTY_PLACEHOLDER_VALUE = "None"
 
-EXCEL_VALUES_TO_BE_TREATED_AS_NONE_VALUE = ("-", EXCEL_PLACEHOLDER_VALUE)
+
+def _is_blank_cell_value(v: object) -> bool:
+    """True for cells with no data to report: None or the placeholder dash."""
+    return v is None or v == "-"
 
 
 def cleanUnitTextFromExcel(unitTest: str, replacements: dict[str, str]) -> str:
@@ -413,10 +417,7 @@ class ExcelProcessor:
                 else:
                     aoixValue = self.getSingleStringValue(namedRangeName).strip()
 
-                if (
-                    not aoixValue
-                    or aoixValue in EXCEL_VALUES_TO_BE_TREATED_AS_NONE_VALUE
-                ):
+                if not aoixValue or aoixValue == "-" or is_error_value(aoixValue):
                     self._results.addMessage(
                         f"Excel report must have a valid value for named range {namedRangeName}.",
                         Severity.ERROR,
@@ -546,7 +547,7 @@ class ExcelProcessor:
         template_version_name = "template_reporting_template_version"
         template_version_string = self.getSingleStringValue(template_version_name)
         excel_version = VersionHolder.parse_safe(template_version_string)
-        converter_version = OUR_VERSION_HOLDER
+        converter_version = OUR_VERSION_HOLDER.strip_build_metadata
 
         major_minor_match = (
             excel_version is not None
@@ -591,9 +592,18 @@ class ExcelProcessor:
                         self.getDefinedNameForString(template_version_name)
                     ),
                 )
-            else:
+            elif excel_version < converter_version:
                 self._results.addMessage(
                     f"The Digital Template is based on version {excel_version}. The latest version available is {converter_version}, please update/migrate to the latest version of the Digital Template, in order to avoid any error message and data loss.",
+                    Severity.WARNING,
+                    MessageType.ExcelParsing,
+                    excel_reference=excelDefinedNameRef(
+                        self.getDefinedNameForString(template_version_name)
+                    ),
+                )
+            else:
+                self._results.addMessage(
+                    f"The Digital Template is based on version {excel_version}, which is newer than the converter version {converter_version}. This may cause errors during conversion. Please use a supported template (the latest version supported by this converter deployment is {converter_version}).",
                     Severity.WARNING,
                     MessageType.ExcelParsing,
                     excel_reference=excelDefinedNameRef(
@@ -1154,7 +1164,16 @@ class ExcelProcessor:
             dimValueDN = periodHolder.definedName
             namedPeriod = dimValueDN.name or ""
             year = self.getSingleValue(dimValueDN)
-            if year is None or year in EXCEL_VALUES_TO_BE_TREATED_AS_NONE_VALUE:
+            if _is_blank_cell_value(year):
+                self._definedNameToXBRLMap.pop(dimValueDN)
+                continue
+            if isinstance(year, str) and is_error_value(year):
+                self._results.addMessage(
+                    f"Named range {namedPeriod} contains an error value '{year}'. Please fix the error in the file.",
+                    Severity.ERROR,
+                    MessageType.ExcelParsing,
+                    excel_reference=excelDefinedNameRef(dimValueDN),
+                )
                 self._definedNameToXBRLMap.pop(dimValueDN)
                 continue
 
@@ -1237,10 +1256,16 @@ class ExcelProcessor:
                                 broken = True
                                 break
 
-                    if (
-                        value is None
-                        or value in EXCEL_VALUES_TO_BE_TREATED_AS_NONE_VALUE
-                    ):
+                    if _is_blank_cell_value(value):
+                        continue
+                    if isinstance(value, str) and is_error_value(value):
+                        self._results.addMessage(
+                            f"Cell in named range {priItem.definedName.name} contains an error value '{value}'. Please fix the error in the file.",
+                            Severity.ERROR,
+                            MessageType.ExcelParsing,
+                            taxonomy_concept=concept,
+                            excel_reference=excelCellRef(priItem.worksheet, cell),
+                        )
                         continue
 
                     factBuilder = self._report.getFactBuilder()
@@ -1618,8 +1643,17 @@ class ExcelProcessor:
                 continue
 
             value = cell.value
-            if value is None or value in EXCEL_VALUES_TO_BE_TREATED_AS_NONE_VALUE:
-                # No value in the cell, so not reportable
+            if _is_blank_cell_value(value):
+                self._definedNameToXBRLMap.pop(dn)
+                continue
+            if isinstance(value, str) and is_error_value(value):
+                self._results.addMessage(
+                    f"Named range {dn.name} contains an error value '{value}'. Please fix the error in the file.",
+                    Severity.ERROR,
+                    MessageType.ExcelParsing,
+                    taxonomy_concept=concept,
+                    excel_reference=excelDefinedNameRef(dn),
+                )
                 self._definedNameToXBRLMap.pop(dn)
                 continue
 

--- a/tests/unitTests/test_version.py
+++ b/tests/unitTests/test_version.py
@@ -1,0 +1,296 @@
+import operator
+import re
+
+import pytest
+
+from mireport.version import (
+    OUR_VERSION,
+    OUR_VERSION_HOLDER,
+    VersionHolder,
+    VersionInformationTuple,
+)
+
+_PACKAGE_INSTALLED = OUR_VERSION != "(unknown version)"
+
+# Official semver regex — oracle for tests, not used in production code.
+_SEMVER_RE = re.compile(
+    r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+)
+
+# Shared invalid version strings — used by TestVersionHolderParse for both parse() and parse_safe().
+_INVALID_VERSION_STRINGS = ["", "1.0", "1.0.x", "not-a-version", "bad"]
+
+
+class TestVersionInformationTuple:
+    @pytest.mark.parametrize(
+        "name,ver,expected",
+        [
+            ("MyTool", "1.2.3", "MyTool (version 1.2.3)"),
+            ("Tool", "0.0.1-alpha", "Tool (version 0.0.1-alpha)"),
+        ],
+    )
+    def test_str(self, name, ver, expected):
+        assert str(VersionInformationTuple(name, ver)) == expected
+
+
+class TestVersionHolderParse:
+    @pytest.mark.parametrize(
+        "version_str,expected",
+        [
+            ("1.0.0", VersionHolder(1, 0, 0, "")),
+            ("1.2.3", VersionHolder(1, 2, 3, "")),
+            ("1.0.0-alpha", VersionHolder(1, 0, 0, "-alpha")),
+            ("1.0.0-rc.1", VersionHolder(1, 0, 0, "-rc.1")),
+            ("1.0.0+build.1", VersionHolder(1, 0, 0, "+build.1")),
+            ("1.0.0-alpha+build.1", VersionHolder(1, 0, 0, "-alpha+build.1")),
+            ("  1.2.3  ", VersionHolder(1, 2, 3, "")),
+            ("0.1.0", VersionHolder(0, 1, 0, "")),
+            ("0.00.0", VersionHolder(0, 0, 0, "")),  # leniency: leading zeros accepted
+        ],
+    )
+    def test_parse_valid(self, version_str, expected):
+        assert VersionHolder.parse(version_str) == expected
+
+    @pytest.mark.parametrize("version_str", _INVALID_VERSION_STRINGS)
+    def test_parse_invalid(self, version_str):
+        with pytest.raises(ValueError):
+            VersionHolder.parse(version_str)
+        assert VersionHolder.parse_safe(version_str) is None
+
+    def test_parse_safe_valid(self):
+        assert VersionHolder.parse_safe("1.2.3") == VersionHolder(1, 2, 3, "")
+
+    def test_parse_safe_strips_whitespace(self):
+        assert VersionHolder.parse_safe("  1.2.3  ") == VersionHolder(1, 2, 3, "")
+
+    @pytest.mark.parametrize(
+        "holder,expected_str",
+        [
+            (VersionHolder(1, 2, 3, ""), "1.2.3"),
+            (VersionHolder(1, 2, 3, "-alpha"), "1.2.3-alpha"),
+            (VersionHolder(1, 0, 0, "+build.1"), "1.0.0+build.1"),
+            (VersionHolder(0, 0, 1, "-rc.1+meta"), "0.0.1-rc.1+meta"),
+        ],
+    )
+    def test_str(self, holder, expected_str):
+        assert str(holder) == expected_str
+
+
+class TestVersionHolderProperties:
+    @pytest.mark.parametrize(
+        "version_str,expected_prerelease,expected_buildmetadata",
+        [
+            ("1.0.0", None, None),
+            ("1.0.0-alpha", "alpha", None),
+            ("1.0.0-beta", "beta", None),
+            ("1.0.0-rc.1", "rc.1", None),
+            ("1.0.0+build.1", None, "build.1"),
+            ("1.0.0-alpha+build.1", "alpha", "build.1"),
+        ],
+    )
+    def test_semver_structure(
+        self, version_str, expected_prerelease, expected_buildmetadata
+    ):
+        m = _SEMVER_RE.match(version_str)
+        assert m is not None, f"{version_str!r} did not match the official semver regex"
+        assert m.group("prerelease") == expected_prerelease
+        assert m.group("buildmetadata") == expected_buildmetadata
+
+        v = VersionHolder.parse(version_str)
+        assert v.prerelease == expected_prerelease
+        assert v.build_metadata == expected_buildmetadata
+
+    @pytest.mark.parametrize(
+        "version_str,expected",
+        [
+            ("1.0.0", False),
+            ("1.0.0-alpha", True),
+            ("1.0.0-rc.1", True),
+            ("1.0.0+build.1", False),
+            ("1.0.0-alpha+build.1", True),
+        ],
+    )
+    def test_is_prerelease(self, version_str, expected):
+        assert VersionHolder.parse(version_str).is_prerelease == expected
+
+    @pytest.mark.parametrize(
+        "version_str,expected",
+        [
+            ("1.0.0", "1.0.0"),
+            ("1.0.0+build.1", "1.0.0"),
+            ("1.0.0-alpha+build.1", "1.0.0-alpha"),
+            ("1.0.0-alpha", "1.0.0-alpha"),
+        ],
+    )
+    def test_strip_build_metadata(self, version_str, expected):
+        assert str(VersionHolder.parse(version_str).strip_build_metadata) == expected
+
+
+class TestVersionHolderEquality:
+    @pytest.mark.parametrize(
+        "a,b,expected",
+        [
+            ("1.0.0", "1.0.0", True),
+            ("1.0.0-alpha", "1.0.0-alpha", True),
+            ("1.0.0-alpha", "1.0.0", False),
+            ("1.0.0", "2.0.0", False),
+            ("1.0.0-alpha", "1.0.0-beta", False),
+        ],
+    )
+    def test_equality(self, a, b, expected):
+        assert (VersionHolder.parse(a) == VersionHolder.parse(b)) == expected
+
+    def test_equality_with_non_version_returns_false(self):
+        # tuple.__eq__ returns False (not NotImplemented) when compared to an unlike type
+        assert VersionHolder.parse("1.0.0") != "1.0.0"
+
+    def test_hashable(self):
+        hash(VersionHolder.parse("1.0.0"))  # must not raise
+
+    def test_equal_instances_same_hash(self):
+        a = VersionHolder.parse("1.0.0-alpha")
+        b = VersionHolder.parse("1.0.0-alpha")
+        assert a == b
+        assert hash(a) == hash(b)
+
+    def test_usable_in_set(self):
+        versions = {
+            VersionHolder.parse("1.0.0"),
+            VersionHolder.parse("1.0.0-alpha"),
+            VersionHolder.parse("1.0.0"),
+        }
+        assert len(versions) == 2
+        assert VersionHolder.parse("1.0.0") in versions
+
+
+class TestVersionHolderOrdering:
+    @pytest.mark.parametrize(
+        "a,b,expected",
+        [
+            # numeric ordering
+            ("1.0.0", "2.0.0", True),
+            ("1.0.0", "1.1.0", True),
+            ("1.0.0", "1.0.1", True),
+            ("2.0.0", "1.0.0", False),
+            ("1.0.0", "1.0.0", False),
+            # pre-release vs release (semver §11.3)
+            ("1.0.0-alpha", "1.0.0", True),
+            ("1.0.0", "1.0.0-alpha", False),
+            # pre-release ordering (lexical within same major.minor.patch)
+            ("1.0.0-alpha", "1.0.0-beta", True),
+            ("1.0.0-beta", "1.0.0-alpha", False),
+            # different patch
+            ("1.0.0", "1.0.1-alpha", True),
+            # build metadata treated as non-pre-release (semver §10 — same precedence as release)
+            ("1.0.0+build.1", "1.0.0", False),
+            ("1.0.0", "1.0.0+build.1", False),
+            ("1.0.0-alpha", "1.0.0+build.1", True),
+            ("1.0.0-alpha+build.1", "1.0.0", True),
+            # build-metadata variants also have same precedence per §10 (a != b but neither a<b nor b<a)
+            ("1.0.0+build.1", "1.0.0+build.2", False),
+            ("1.0.0+build.2", "1.0.0+build.1", False),
+        ],
+    )
+    def test_less_than(self, a, b, expected):
+        assert (VersionHolder.parse(a) < VersionHolder.parse(b)) == expected
+
+    @pytest.mark.parametrize(
+        "method,name",
+        [
+            (VersionHolder.__lt__, "__lt__"),
+            (VersionHolder.__gt__, "__gt__"),
+            (VersionHolder.__le__, "__le__"),
+            (VersionHolder.__ge__, "__ge__"),
+        ],
+    )
+    def test_comparison_non_version_returns_not_implemented(self, method, name):
+        result = method(VersionHolder.parse("1.0.0"), "1.0.0")
+        assert result is NotImplemented, (
+            f"{name} should return NotImplemented for non-VersionHolder"
+        )
+
+    @pytest.mark.parametrize(
+        "a,b,op,expected",
+        [
+            ("1.0.0", "1.0.0-alpha", operator.gt, True),
+            ("1.0.0-alpha", "1.0.0", operator.gt, False),
+            ("1.0.0+build.1", "1.0.0", operator.gt, False),  # §10: equal precedence
+            ("1.0.0-alpha", "1.0.0", operator.le, True),
+            ("1.0.0", "1.0.0", operator.le, True),
+            ("1.0.0", "1.0.0+build.1", operator.le, True),  # §10: equal precedence
+            ("1.0.0", "1.0.0", operator.ge, True),
+            ("1.0.0", "1.0.0-alpha", operator.ge, True),
+            ("1.0.0-alpha", "1.0.0", operator.ge, False),
+            ("1.0.0", "1.0.0+build.1", operator.ge, True),  # §10: equal precedence
+        ],
+    )
+    def test_derived_operators(self, a, b, op, expected):
+        assert op(VersionHolder.parse(a), VersionHolder.parse(b)) == expected
+
+    @pytest.mark.parametrize(
+        "unsorted,expected",
+        [
+            # basic ordering across all semver precedence rules
+            (
+                ["1.0.0", "2.0.0-alpha", "1.0.0-beta", "2.0.0", "1.0.1"],
+                ["1.0.0-beta", "1.0.0", "1.0.1", "2.0.0-alpha", "2.0.0"],
+            ),
+            # §10: build metadata has equal precedence — stable sort preserves input order (release first)
+            (
+                [
+                    "1.0.0",
+                    "2.0.0-alpha",
+                    "1.0.0-beta",
+                    "2.0.0",
+                    "1.0.1",
+                    "1.0.0+build.1",
+                ],
+                [
+                    "1.0.0-beta",
+                    "1.0.0",
+                    "1.0.0+build.1",
+                    "1.0.1",
+                    "2.0.0-alpha",
+                    "2.0.0",
+                ],
+            ),
+            # §10: build metadata has equal precedence — stable sort preserves input order (build first)
+            (
+                [
+                    "1.0.0+build.1",
+                    "2.0.0-alpha",
+                    "1.0.0-beta",
+                    "2.0.0",
+                    "1.0.1",
+                    "1.0.0",
+                ],
+                [
+                    "1.0.0-beta",
+                    "1.0.0+build.1",
+                    "1.0.0",
+                    "1.0.1",
+                    "2.0.0-alpha",
+                    "2.0.0",
+                ],
+            ),
+        ],
+    )
+    def test_sortable(self, unsorted, expected):
+        assert [
+            str(v) for v in sorted(VersionHolder.parse(s) for s in unsorted)
+        ] == expected
+
+
+class TestModuleExports:
+    @pytest.mark.skipif(not _PACKAGE_INSTALLED, reason="package not pip-installed")
+    def test_our_version_importable(self):
+        assert isinstance(OUR_VERSION, str)
+        assert len(OUR_VERSION) > 0
+        assert isinstance(OUR_VERSION_HOLDER, VersionHolder)
+        assert str(OUR_VERSION_HOLDER) == OUR_VERSION
+        assert _SEMVER_RE.match(OUR_VERSION) is not None, (
+            f"OUR_VERSION {OUR_VERSION!r} is not valid semver"
+        )

--- a/tests/unitTests/test_version.py
+++ b/tests/unitTests/test_version.py
@@ -1,13 +1,18 @@
+import json
 import operator
 import re
+import subprocess
+from importlib.metadata import PackageNotFoundError
 
 import pytest
 
+import mireport.version as version_module
 from mireport.version import (
     OUR_VERSION,
     OUR_VERSION_HOLDER,
     VersionHolder,
     VersionInformationTuple,
+    _editable_suffix,
 )
 
 _PACKAGE_INSTALLED = OUR_VERSION != "(unknown version)"
@@ -282,6 +287,177 @@ class TestVersionHolderOrdering:
         assert [
             str(v) for v in sorted(VersionHolder.parse(s) for s in unsorted)
         ] == expected
+
+
+def _install_fake_distribution(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    payload: str | None = None,
+    read_error: Exception | None = None,
+    from_name_error: Exception | None = None,
+) -> None:
+    """Replace version.Distribution so from_name() yields a stub direct_url.json."""
+
+    class FakeDist:
+        def read_text(self, filename: str) -> str | None:
+            assert filename == "direct_url.json"
+            if read_error is not None:
+                raise read_error
+            return payload
+
+    class FakeDistribution:
+        @staticmethod
+        def from_name(name: str) -> FakeDist:
+            if from_name_error is not None:
+                raise from_name_error
+            return FakeDist()
+
+    monkeypatch.setattr(version_module, "Distribution", FakeDistribution)
+
+
+def _install_fake_git(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stdout: str = "",
+    error: Exception | None = None,
+) -> None:
+    """Replace subprocess.run so `git describe` returns stdout (or raises)."""
+
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        if error is not None:
+            raise error
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout)
+
+    monkeypatch.setattr(version_module.subprocess, "run", fake_run)
+
+
+def _editable_payload(url: str = "file:///src/project") -> str:
+    return json.dumps({"dir_info": {"editable": True}, "url": url})
+
+
+class TestEditableSuffix:
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        # _editable_suffix is @cache'd, so every test needs a clean slate.
+        _editable_suffix.cache_clear()
+        yield
+        _editable_suffix.cache_clear()
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            pytest.param(None, id="no-direct_url.json"),
+            pytest.param("", id="empty-file"),
+            pytest.param("{not json", id="invalid-json"),
+            pytest.param("[1, 2, 3]", id="json-is-a-list"),
+            pytest.param('"hello"', id="json-is-a-string"),
+            pytest.param("null", id="json-is-null"),
+            pytest.param("{}", id="no-dir_info"),
+            pytest.param('{"dir_info": true}', id="dir_info-not-an-object"),
+            pytest.param('{"dir_info": {"editable": false}}', id="editable-false"),
+            pytest.param('{"dir_info": {}}', id="editable-absent"),
+            pytest.param('{"dir_info": {"editable": true}}', id="url-absent"),
+            pytest.param(
+                '{"dir_info": {"editable": true}, "url": 42}', id="url-not-a-string"
+            ),
+            pytest.param(
+                '{"dir_info": {"editable": true}, "url": "https://example.com/x"}',
+                id="url-not-a-file-url",
+            ),
+        ],
+    )
+    def test_returns_empty_for_non_editable_or_malformed_metadata(
+        self, monkeypatch, payload
+    ):
+        """Anything unexpected in direct_url.json is an early return, not an exception.
+
+        Guards these paths against a regression to `data.get(...)` on a non-dict,
+        which would raise AttributeError out of module import.
+        """
+        _install_fake_distribution(monkeypatch, payload=payload)
+        assert _editable_suffix() == ""
+
+    def test_returns_empty_when_package_not_installed(self, monkeypatch):
+        _install_fake_distribution(
+            monkeypatch, from_name_error=PackageNotFoundError("nope")
+        )
+        assert _editable_suffix() == ""
+
+    def test_returns_empty_when_direct_url_json_is_not_utf8(self, monkeypatch):
+        # Distribution.read_text() suppresses missing/unreadable files but lets
+        # UnicodeDecodeError through.
+        _install_fake_distribution(
+            monkeypatch,
+            read_error=UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte"),
+        )
+        assert _editable_suffix() == ""
+
+    @pytest.mark.parametrize(
+        "git_output,expected",
+        [
+            # Long form "tag-N-ghash" is reduced to just the hash.
+            ("version/1.3.0-22-g4c86c9f", "+git.4c86c9f"),
+            ("version/1.3.0-22-g4c86c9f.dirty", "+git.4c86c9f.dirty"),
+            # Sitting exactly on a tag: the whole tag is used, sanitised.
+            ("version/1.3.0", "+git.version-1.3.0"),
+            ("1.3.0", "+git.1.3.0"),
+            # No tags reachable, so --always gives a bare hash.
+            ("4c86c9f", "+git.4c86c9f"),
+            ("4c86c9f.dirty", "+git.4c86c9f.dirty"),
+            # Characters semver forbids in build metadata become '-'.
+            ("release/v1.0_rc1", "+git.release-v1.0-rc1"),
+            ("feature/oh~no", "+git.feature-oh-no"),
+            # Surrounding whitespace from git is stripped.
+            ("  4c86c9f\n", "+git.4c86c9f"),
+        ],
+    )
+    def test_git_describe_output_becomes_suffix(
+        self, monkeypatch, git_output, expected
+    ):
+        _install_fake_distribution(monkeypatch, payload=_editable_payload())
+        _install_fake_git(monkeypatch, stdout=git_output)
+        assert _editable_suffix() == expected
+
+    @pytest.mark.parametrize(
+        "git_output",
+        [
+            "version/1.3.0-22-g4c86c9f.dirty",
+            "version/1.3.0",
+            "release/v1.0_rc1",
+            "feature/oh~no",
+            "4c86c9f",
+        ],
+    )
+    def test_suffix_is_valid_semver_build_metadata(self, monkeypatch, git_output):
+        """The sanitising regex exists so the result is appendable to a semver core."""
+        _install_fake_distribution(monkeypatch, payload=_editable_payload())
+        _install_fake_git(monkeypatch, stdout=git_output)
+        assert _SEMVER_RE.match(f"1.2.3{_editable_suffix()}") is not None
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            pytest.param(subprocess.CalledProcessError(128, "git"), id="non-zero-exit"),
+            pytest.param(subprocess.TimeoutExpired("git", 5), id="timeout"),
+            pytest.param(FileNotFoundError("git"), id="git-not-on-path"),
+            pytest.param(PermissionError("git"), id="not-executable"),
+            pytest.param(NotADirectoryError("cwd"), id="source-dir-gone"),
+        ],
+    )
+    def test_returns_empty_when_git_fails(self, monkeypatch, error):
+        _install_fake_distribution(monkeypatch, payload=_editable_payload())
+        _install_fake_git(monkeypatch, error=error)
+        assert _editable_suffix() == ""
+
+    def test_unexpected_exception_is_not_swallowed(self, monkeypatch):
+        """The except clause is deliberately narrow.
+
+        Anything outside the handled categories is a bug in this function (a typo,
+        say) and must surface rather than be hidden behind an empty suffix.
+        """
+        _install_fake_distribution(monkeypatch, read_error=RuntimeError("boom"))
+        with pytest.raises(RuntimeError, match="boom"):
+            _editable_suffix()
 
 
 class TestModuleExports:


### PR DESCRIPTION
Add test_version.py (80 cases) plus migrate-related fixes across
version.py, migration.py, conversionresults.py, xlsx_template_reader,
and migration/base templates.
