### PR TITLE
strr/ruff upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "pytest-cov>=4.0.0",
     "pytest-flask>=1.3.0",
     "pytest>=7.0.0",
-    "ruff>=0.12.2",
+    "ruff>=0.16",
     "safety>=3.2.9",
     "types-lxml",
     "types-openpyxl",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,3 +98,18 @@ src = ["src"]
 
 [tool.ruff.lint]
 extend-select = ["I"]
+
+[tool.ruff.lint.per-file-ignores]
+# BLE001 (blind except). These modules are the processing boundaries: Flask
+# request handlers, calls into Arelle and parsing of user supplied Excel. They
+# deliberately catch Exception and turn the failure into a user visible message
+# rather than let it escape. Ruff cannot see that these are handled: its
+# exemption for logged exceptions only fires for loggers it recognises by name
+# and ours are all called `L`. Elsewhere BLE001 stays on, so one-off blind
+# excepts in library code need a noqa that says why.
+"src/digital_converter_webapp/*.py" = ["BLE001"]
+"src/mireport/arelle/report_info.py" = ["BLE001"]
+"src/mireport/xlsx_template_reader/processor.py" = ["BLE001"]
+
+# Test package directories are camelCase to match the rest of the test suite.
+"tests/**" = ["N999"]

--- a/scripts/check-report.py
+++ b/scripts/check-report.py
@@ -3,7 +3,6 @@ import glob
 import logging
 import time
 from pathlib import Path
-from typing import Optional
 
 from mireport.arelle.report_info import ArelleReportProcessor, getOrCreateReportPackage
 from mireport.cli import configure_rich_output
@@ -86,8 +85,8 @@ def main() -> None:
 
     report_path: Path = args.report_path
     taxonomy_package_globs: list[str] = args.taxonomy_packages
-    viewer_path: Optional[Path] = args.viewer_path
-    json_path: Optional[Path] = args.json_path
+    viewer_path: Path | None = args.viewer_path
+    json_path: Path | None = args.json_path
 
     taxonomy_packages: list[Path] = []
     if taxonomy_package_globs:

--- a/scripts/check-report.py
+++ b/scripts/check-report.py
@@ -104,10 +104,10 @@ def main() -> None:
         )
         print("Zip files to use  ", " ".join(str(t) for t in taxonomy_packages))
 
-        if not all([taxonomy_zip.is_file() for taxonomy_zip in taxonomy_packages]):
+        if not all(taxonomy_zip.is_file() for taxonomy_zip in taxonomy_packages):
             raise SystemExit(f"Not all specified files found: {taxonomy_packages}")
         elif not all(
-            [".zip" == taxonomy_zip.suffix for taxonomy_zip in taxonomy_packages]
+            ".zip" == taxonomy_zip.suffix for taxonomy_zip in taxonomy_packages
         ):
             raise SystemExit(
                 f"Not all specified files are Zip files: {taxonomy_packages}"

--- a/scripts/parse-and-dump.py
+++ b/scripts/parse-and-dump.py
@@ -65,7 +65,7 @@ def dump_data(candidates: list, verbose: bool) -> None:
         print(f"{name}: ({num} cells in range)")
         print("\t", end="")
 
-        if all([x is None for x in cells]):
+        if all(x is None for x in cells):
             print("(all cells empty)")
             continue
 

--- a/scripts/parse-and-dump.py
+++ b/scripts/parse-and-dump.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import time
 from argparse import ArgumentParser, BooleanOptionalAction
 from contextlib import closing

--- a/scripts/parse-and-ixbrl.py
+++ b/scripts/parse-and-ixbrl.py
@@ -388,7 +388,6 @@ def outputMessages(
             *unused,
             sep="\n\t",
         )
-    return
 
 
 def main() -> None:
@@ -396,7 +395,6 @@ def main() -> None:
     args = parseArgs(parser)
     result, excel = doConversion(args)
     outputMessages(args, result, excel)
-    return
 
 
 if __name__ == "__main__":

--- a/src/digital_converter_webapp/__init__.py
+++ b/src/digital_converter_webapp/__init__.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Mapping
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from random import randint
 from secrets import token_hex
 from typing import Any
@@ -60,7 +60,7 @@ from .migration import (
 
 MAX_LIVE_CAPTCHAS = 20  # answers kept per session (multiple tabs/reloads)
 MAX_FILE_SIZE = 16 * 2**20  # 16 MiB
-DEPLOYMENT_DATETIME = datetime.now(timezone.utc)
+DEPLOYMENT_DATETIME = datetime.now(UTC)
 
 L = logging.getLogger(__name__)
 
@@ -419,7 +419,7 @@ def upload() -> Response:
         )
     result = ConversionResultsBuilder()
     conversion = session.setdefault(result.conversionId, {"id": result.conversionId})
-    conversion["date"] = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    conversion["date"] = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
     conversion["excel"] = FilelikeAndFileName(
         fileContent=blob.stream.read(), filename=blob.filename
     )

--- a/src/digital_converter_webapp/__init__.py
+++ b/src/digital_converter_webapp/__init__.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Mapping
-from datetime import UTC, datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from random import randint
 from secrets import token_hex
 from typing import Any

--- a/src/digital_converter_webapp/migration.py
+++ b/src/digital_converter_webapp/migration.py
@@ -159,7 +159,7 @@ def migrationPage(id: str) -> Response:
         )
     except Exception as e:
         L.exception("Exception during migration page display", exc_info=e)
-        flash(f"Migration page failed to load: {str(e)}", "error")
+        flash(f"Migration page failed to load: {e!s}", "error")
         return make_response(redirect(url_for("basic.index")))
 
 

--- a/src/mireport/arelle/report_info.py
+++ b/src/mireport/arelle/report_info.py
@@ -94,7 +94,7 @@ class ArelleReportProcessor:
                     PluginManager.reset()
                     PluginManager.close()
                 except Exception:
-                    pass
+                    L.exception("Failed to reset Arelle package and plugin managers")
                 with (
                     Session() as session,
                     reportPackage.fileLike() as requestZipStream,
@@ -309,7 +309,8 @@ ARELLE_VIEWER_URL = ArelleReportProcessor._determineViewerUrl()
 
 
 def getOrCreateReportPackage(reportPackage: Path) -> FilelikeAndFileName:
-    """"""
+    """Return the given zip as-is, or wrap a single inline report document in an
+    unconstrained report package."""
     if not isinstance(reportPackage, Path):
         raise ArelleRelatedException(
             f"Passed a report package {reportPackage=} that is not a Path"

--- a/src/mireport/arelle/report_info.py
+++ b/src/mireport/arelle/report_info.py
@@ -9,7 +9,7 @@ from pathlib import Path, PurePath
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import BinaryIO, Optional
+    from typing import BinaryIO
 
 from arelle import PackageManager, PluginManager
 from arelle.api.Session import Session
@@ -35,7 +35,7 @@ class ArelleReportProcessor:
     def __init__(
         self,
         *,
-        taxonomyPackages: Optional[list[Path]] = None,
+        taxonomyPackages: list[Path] | None = None,
         workOffline: bool = True,
     ):
         self.workOffline = bool(workOffline)
@@ -47,7 +47,7 @@ class ArelleReportProcessor:
         self,
         reportPackage: FilelikeAndFileName,
         options: RuntimeOptions,
-        responseZipStream: Optional[BinaryIO] = None,
+        responseZipStream: BinaryIO | None = None,
     ) -> ArelleProcessingResult:
         ###############################
         #  Arelle is _NOT_ thread safe.
@@ -245,7 +245,7 @@ class ArelleReportProcessor:
 
     @staticmethod
     def getTaxonomyPackagesFromDir(
-        taxonomyPackageDir: Optional[str | Path],
+        taxonomyPackageDir: str | Path | None,
     ) -> list[Path]:
         if taxonomyPackageDir is None:
             return []

--- a/src/mireport/arelle/support.py
+++ b/src/mireport/arelle/support.py
@@ -28,7 +28,6 @@ class ArelleRelatedException(MIReportException):
     """Exception to wrap any exception that come from calling in to Arelle."""
 
 
-
 @dataclass
 class ArelleVersionHolder:
     arelle: VersionInformationTuple

--- a/src/mireport/arelle/support.py
+++ b/src/mireport/arelle/support.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Any, ClassVar, Optional, Self
+    from typing import Any, ClassVar, Self
 
 from arelle.api.Session import Session
 from arelle.ModelValue import QName
@@ -27,7 +27,6 @@ L = logging.getLogger(__name__)
 class ArelleRelatedException(MIReportException):
     """Exception to wrap any exception that come from calling in to Arelle."""
 
-    pass
 
 
 @dataclass
@@ -56,8 +55,8 @@ class ArelleProcessingResult:
     def __init__(self, jsonMessages: str, textLogLines: list[str]):
         self._validationMessages: list[Message] = []
         self._textLogLines: list[str] = textLogLines
-        self._viewer: Optional[FilelikeAndFileName] = None
-        self._xbrlJson: Optional[FilelikeAndFileName] = None
+        self._viewer: FilelikeAndFileName | None = None
+        self._xbrlJson: FilelikeAndFileName | None = None
         self.__importArelleMessages(jsonMessages)
         self._exceptions: list[Exception] = []
 
@@ -68,7 +67,7 @@ class ArelleProcessingResult:
             code: str = r.get("code", "")
             level: str = r.get("level", "")
             text: str = r.get("message", {}).get("text", "")
-            fact: Optional[str] = r.get("message", {}).get("fact")
+            fact: str | None = r.get("message", {}).get("fact")
 
             if wantDebug:
                 L.debug(f"Record: {r=}")
@@ -156,7 +155,7 @@ class ArelleProcessingResult:
     def logLines(self) -> list[str]:
         return list(self._textLogLines)
 
-    def addException(self, exception: Exception, message: Optional[str] = None) -> None:
+    def addException(self, exception: Exception, message: str | None = None) -> None:
         self._exceptions.append(exception)
         text = f"{exception.__class__.__name__}: {exception}"
         if message:

--- a/src/mireport/arelle/taxonomy_info.py
+++ b/src/mireport/arelle/taxonomy_info.py
@@ -561,12 +561,10 @@ class TaxonomyInfoExtractor:
                         "order": r.order,
                         "parts": ref_parts,
                         "sort_key": (
-                                r.order,
-                                role,
-                                tuple(
-                                    (str(name), str(value)) for name, value in ref_parts
-                                ),
-                            ),
+                            r.order,
+                            role,
+                            tuple((str(name), str(value)) for name, value in ref_parts),
+                        ),
                     }
                 )
 

--- a/src/mireport/arelle/taxonomy_info.py
+++ b/src/mireport/arelle/taxonomy_info.py
@@ -8,7 +8,7 @@ from collections.abc import Iterable, MutableMapping
 from typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
-    from typing import Any, Optional
+    from typing import Any
 
 from arelle import XbrlConst
 from arelle.api.Session import Session
@@ -60,7 +60,7 @@ def callArelleForTaxonomyInfo(
     entry_point: str,
     taxonomy_zips: list[str],
     taxonomy_json_path: str,
-    utr_json_path: Optional[str] = None,
+    utr_json_path: str | None = None,
 ) -> ArelleProcessingResult:
     pluginOptions: dict[str, RuntimeOptionValue] = {
         "taxonomyDataFile": taxonomy_json_path
@@ -613,7 +613,7 @@ class TaxonomyInfoExtractor:
                 if concept.isEnumeration and not concept.isEnumeration2Item:
                     self.cntlr.addToLog(
                         f"WARNING: Extensible enumerations other than 2.0 are not supported. {concept.qname}",
-                        level=logging.WARN,
+                        level=logging.WARNING,
                     )
                 if concept.isEnumeration2Item:
                     headUsable = concept.isEnumDomainUsable

--- a/src/mireport/arelle/taxonomy_info.py
+++ b/src/mireport/arelle/taxonomy_info.py
@@ -5,6 +5,7 @@ import logging
 import time
 from collections import defaultdict
 from collections.abc import Iterable, MutableMapping
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
@@ -94,9 +95,12 @@ def callArelleForTaxonomyInfo(
     return results
 
 
+@dataclass
 class TaxonomyInfoPluginData(PluginData):
-    Taxonomy: dict = {}
-    UTR: dict = {}
+    # N.B. per-instance dicts. Plain class attributes would be shared by every
+    # Cntlr that loads this plugin.
+    Taxonomy: dict = field(default_factory=dict)
+    UTR: dict = field(default_factory=dict)
 
 
 def pluginData(cntlr: Cntlr) -> TaxonomyInfoPluginData:

--- a/src/mireport/arelle/taxonomy_info.py
+++ b/src/mireport/arelle/taxonomy_info.py
@@ -95,8 +95,8 @@ def callArelleForTaxonomyInfo(
 
 
 class TaxonomyInfoPluginData(PluginData):
-    Taxonomy: dict = dict()
-    UTR: dict = dict()
+    Taxonomy: dict = {}
+    UTR: dict = {}
 
 
 def pluginData(cntlr: Cntlr) -> TaxonomyInfoPluginData:
@@ -171,7 +171,7 @@ class UTRInfoExtractor:
         ]
         utrEntries = [
             u
-            for dataTypeIsh in self.utrModel.keys()
+            for dataTypeIsh in self.utrModel
             for u in self.utrModel[dataTypeIsh].values()
         ]
         for entry in sorted(utrEntries, key=lambda e: e.unitId):
@@ -459,7 +459,7 @@ class TaxonomyInfoExtractor:
 
     def extractDimensionDefaults(self) -> None:
         elrsWithDefaults = set()
-        for arcroleUri, elrUri, linkqname, arcqname in self.modelXbrl.baseSets.keys():
+        for arcroleUri, elrUri, linkqname, arcqname in self.modelXbrl.baseSets:
             if arcroleUri == XbrlConst.dimensionDefault and elrUri is not None:
                 elrsWithDefaults.add(elrUri)
 
@@ -560,15 +560,13 @@ class TaxonomyInfoExtractor:
                         "role": role,
                         "order": r.order,
                         "parts": ref_parts,
-                        "sort_key": tuple(
-                            (
+                        "sort_key": (
                                 r.order,
                                 role,
                                 tuple(
                                     (str(name), str(value)) for name, value in ref_parts
                                 ),
-                            )
-                        ),
+                            ),
                     }
                 )
 
@@ -577,7 +575,7 @@ class TaxonomyInfoExtractor:
 
             if not all_order1:
                 self.cntlr.addToLog(
-                    f"INFO: {concept.qname} uses references with order values other than 1. Orders found: {sorted(set(r['order'] for r in refs))}. References will be sorted by order.",
+                    f"INFO: {concept.qname} uses references with order values other than 1. Orders found: {sorted({r['order'] for r in refs})}. References will be sorted by order.",
                     level=logging.INFO,
                 )
 
@@ -636,7 +634,7 @@ class TaxonomyInfoExtractor:
         self.taxonomyJson["dimensions"] = defaultdict(dict)
         # Get the hypercubes and primary items
         hypercubeArcRoles = (XbrlConst.all, XbrlConst.notAll)
-        for arcroleUri, elrUri, linkqname, arcqname in self.modelXbrl.baseSets.keys():
+        for arcroleUri, elrUri, linkqname, arcqname in self.modelXbrl.baseSets:
             if linkqname is None or arcqname is None:
                 continue
             if arcroleUri in hypercubeArcRoles and elrUri is not None:
@@ -712,7 +710,7 @@ class TaxonomyInfoExtractor:
 
     def extractPresentation(self) -> None:
         self.cntlr.addToLog("Processing presentation network")
-        for arcroleUri, elrUri, linkqname, arcqname in self.modelXbrl.baseSets.keys():
+        for arcroleUri, elrUri, linkqname, arcqname in self.modelXbrl.baseSets:
             # cntlr.addToLog(f"{arcroleUri}, {elrUri}, {linkqname}, {arcqname}")
             if linkqname is None or arcqname is None:
                 continue

--- a/src/mireport/cli.py
+++ b/src/mireport/cli.py
@@ -68,8 +68,8 @@ def validateTaxonomyPackages(globList: list[str], parser: ArgumentParser) -> lis
     taxonomy_zips: list[str] = getListofPathsFromListOfGlobs(globList)
     console_print("Zip files to use  ", " ".join(taxonomy_zips))
 
-    if not all([os.path.exists(taxonomy_zip) for taxonomy_zip in taxonomy_zips]):
+    if not all(os.path.exists(taxonomy_zip) for taxonomy_zip in taxonomy_zips):
         raise parser.error(f"Not all specified files found: {taxonomy_zips}")
-    elif not all([taxonomy_zip.endswith(".zip") for taxonomy_zip in taxonomy_zips]):
+    elif not all(taxonomy_zip.endswith(".zip") for taxonomy_zip in taxonomy_zips):
         raise parser.error(f"Not all specified files are Zip files: {taxonomy_zips}")
     return taxonomy_zips

--- a/src/mireport/conversionresults.py
+++ b/src/mireport/conversionresults.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
+    from collections.abc import Set as AbstractSet
     from types import TracebackType
     from typing import Self
 
@@ -95,6 +96,12 @@ class MessageType(StrEnum):
     @lru_cache(1)
     def maxValueWidth(cls) -> int:
         return max(len(s.value) for s in cls.__members__.values())
+
+
+# N.B. frozen so they are safe to use as argument defaults, which are evaluated
+# once and then shared by every call.
+ALL_MESSAGE_TYPES: frozenset[MessageType] = frozenset(MessageType.all())
+ALL_SEVERITIES: frozenset[Severity] = frozenset(Severity.all())
 
 
 class Message:
@@ -234,8 +241,8 @@ class ConversionResults:
     def getMessages(
         self,
         *,
-        wantedMessageTypes: set[MessageType] = MessageType.all(),
-        wantedMessageSeverities: set[Severity] = Severity.all(),
+        wantedMessageTypes: AbstractSet[MessageType] = ALL_MESSAGE_TYPES,
+        wantedMessageSeverities: AbstractSet[Severity] = ALL_SEVERITIES,
     ) -> list[Message]:
         messages = [
             m
@@ -255,7 +262,6 @@ class ConversionResults:
             wantedMessageTypes=MessageType.allExcept(
                 MessageType.DevInfo, MessageType.Progress
             ),
-            wantedMessageSeverities=Severity.all(),
         )
 
     @property

--- a/src/mireport/conversionresults.py
+++ b/src/mireport/conversionresults.py
@@ -289,7 +289,7 @@ class ConversionResultsBuilder(ConversionResults):
             self.conversionId = conversionId
         else:
             self.conversionId = str(uuid.uuid4())
-        self.messages: list[Message] = list()
+        self.messages: list[Message] = []
         self.cellsQueriedBuilder: set[tuple[str, int, int]] = set()
         self.cellsPopulatedBuilder: set[tuple[str, int, int]] = set()
         self.consoleOutput = consoleOutput

--- a/src/mireport/conversionresults.py
+++ b/src/mireport/conversionresults.py
@@ -409,9 +409,7 @@ class ProcessingContext:
     def addDevInfoMessage(self, message: str) -> None:
         self._resultsBuilder.addMessage(message, Severity.INFO, MessageType.DevInfo)
 
-    def mark(
-        self, newSectionName: str | None = None, additionalInfo: str = ""
-    ) -> None:
+    def mark(self, newSectionName: str | None = None, additionalInfo: str = "") -> None:
         now = perf_counter_ns()
         if self.current_section_name is not None:
             execution_time_ns = now - self.current_section_start_time

--- a/src/mireport/conversionresults.py
+++ b/src/mireport/conversionresults.py
@@ -9,9 +9,9 @@ from types import MappingProxyType
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Mapping
     from types import TracebackType
-    from typing import Mapping, Optional, Self, Type
+    from typing import Self
 
 from mireport.exceptions import EarlyAbortException
 from mireport.stringutil import format_time_ns
@@ -35,7 +35,7 @@ class Severity(StrEnum):
 
     @classmethod
     @lru_cache(32)
-    def fromLogLevelString(cls, level: str, *, default: Optional[Self] = None) -> Self:
+    def fromLogLevelString(cls, level: str, *, default: Self | None = None) -> Self:
         # return cls.__members__.get(level.title(), cls(cls.WARNING.value))
         lower_lookup = {k.lower(): v for k, v in cls.__members__.items()}
         level_lower = level.lower()
@@ -103,14 +103,14 @@ class Message:
         messageText: str,
         severity: Severity,
         messageType: MessageType,
-        conceptQName: Optional[str] = None,
-        excelReference: Optional[str] = None,
+        conceptQName: str | None = None,
+        excelReference: str | None = None,
     ):
         self.messageText: str = messageText
         self.severity: Severity = severity
         self.messageType: MessageType = messageType
-        self.conceptQName: Optional[str] = conceptQName
-        self.excelReference: Optional[str] = excelReference
+        self.conceptQName: str | None = conceptQName
+        self.excelReference: str | None = excelReference
 
     def __str__(self) -> str:
         bits = [
@@ -283,7 +283,7 @@ class ConversionResults:
 
 class ConversionResultsBuilder(ConversionResults):
     def __init__(
-        self, conversionId: Optional[str] = None, consoleOutput: bool = False
+        self, conversionId: str | None = None, consoleOutput: bool = False
     ) -> None:
         if conversionId is not None:
             self.conversionId = conversionId
@@ -316,10 +316,10 @@ class ConversionResultsBuilder(ConversionResults):
         severity: Severity,
         message_type: MessageType,
         *,
-        taxonomy_concept: Optional[QName | Concept] = None,
-        excel_reference: Optional[str] = None,
+        taxonomy_concept: QName | Concept | None = None,
+        excel_reference: str | None = None,
     ) -> Self:
-        concept_str_or_none: Optional[str]
+        concept_str_or_none: str | None
         if taxonomy_concept is None:
             concept_str_or_none = taxonomy_concept
         else:
@@ -335,7 +335,7 @@ class ConversionResultsBuilder(ConversionResults):
         )
         return self
 
-    def processingContext(self, name: str) -> "ProcessingContext":
+    def processingContext(self, name: str) -> ProcessingContext:
         return ProcessingContext(self, name)
 
     def addMessages(self, messages: Iterable[Message]) -> Self:
@@ -363,7 +363,7 @@ class ProcessingContext:
         self.succeeded: bool = False
         self.start_time: int
         self.current_section_start_time: int
-        self.current_section_name: Optional[str] = None
+        self.current_section_name: str | None = None
         self.console = self._resultsBuilder.consoleOutput
 
     def __enter__(self) -> Self:
@@ -373,9 +373,9 @@ class ProcessingContext:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_value: Optional[BaseException],
-        traceback: Optional[TracebackType],
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
     ) -> bool:
         self.mark()
         execution_time_ns = perf_counter_ns() - self.start_time
@@ -410,7 +410,7 @@ class ProcessingContext:
         self._resultsBuilder.addMessage(message, Severity.INFO, MessageType.DevInfo)
 
     def mark(
-        self, newSectionName: Optional[str] = None, additionalInfo: str = ""
+        self, newSectionName: str | None = None, additionalInfo: str = ""
     ) -> None:
         now = perf_counter_ns()
         if self.current_section_name is not None:
@@ -425,4 +425,3 @@ class ProcessingContext:
             self._logProgress(
                 f"Starting: [{self.current_section_name}]. {additionalInfo}"
             )
-        return

--- a/src/mireport/exceptions.py
+++ b/src/mireport/exceptions.py
@@ -2,47 +2,37 @@ class MIReportException(Exception):
     """Base class for any XBRL related exceptions. Not expected to be raised directly."""
 
 
-
 class UnitException(MIReportException):
     """Exception raised when a unit is not found in the UTR."""
-
 
 
 class TaxonomyException(MIReportException):
     """All taxonomy related exceptions"""
 
 
-
 class InlineReportException(MIReportException):
     """All Inline XBRL Report related exceptions"""
-
 
 
 class UnknownTaxonomyException(TaxonomyException):
     """Exception raised when a taxonomy entry point is unknown."""
 
 
-
 class BrokenNamespacePrefixException(MIReportException):
     """Exception raised when a prefix is bound to more than one namespace."""
-
 
 
 class BrokenQNameException(MIReportException):
     """Exception raised when a QName is malformed."""
 
 
-
 class AmbiguousComponentException(TaxonomyException):
     """Exception raised when a label or unqualified concept name is used to refer to a concept and it matches more than one concept (it is ambiguous)."""
-
 
 
 class OpenPyXlRelatedException(MIReportException):
     """Exception raised when dealing with an issue in OpenPyXL"""
 
 
-
 class EarlyAbortException(MIReportException):
     """Exception raised when a required field is missing in the report."""
-

--- a/src/mireport/exceptions.py
+++ b/src/mireport/exceptions.py
@@ -1,58 +1,48 @@
 class MIReportException(Exception):
     """Base class for any XBRL related exceptions. Not expected to be raised directly."""
 
-    pass
 
 
 class UnitException(MIReportException):
     """Exception raised when a unit is not found in the UTR."""
 
-    pass
 
 
 class TaxonomyException(MIReportException):
     """All taxonomy related exceptions"""
 
-    pass
 
 
 class InlineReportException(MIReportException):
     """All Inline XBRL Report related exceptions"""
 
-    pass
 
 
 class UnknownTaxonomyException(TaxonomyException):
     """Exception raised when a taxonomy entry point is unknown."""
 
-    pass
 
 
 class BrokenNamespacePrefixException(MIReportException):
     """Exception raised when a prefix is bound to more than one namespace."""
 
-    pass
 
 
 class BrokenQNameException(MIReportException):
     """Exception raised when a QName is malformed."""
 
-    pass
 
 
 class AmbiguousComponentException(TaxonomyException):
     """Exception raised when a label or unqualified concept name is used to refer to a concept and it matches more than one concept (it is ambiguous)."""
 
-    pass
 
 
 class OpenPyXlRelatedException(MIReportException):
     """Exception raised when dealing with an issue in OpenPyXL"""
 
-    pass
 
 
 class EarlyAbortException(MIReportException):
     """Exception raised when a required field is missing in the report."""
 
-    pass

--- a/src/mireport/filesupport.py
+++ b/src/mireport/filesupport.py
@@ -48,10 +48,7 @@ def is_valid_filename(filename: str) -> bool:
         return False
 
     # Ensure filename does not contain invalid characters
-    if FILE_UNWANTED_RE.search(filename):
-        return False
-
-    return True
+    return not FILE_UNWANTED_RE.search(filename)
 
 
 def zipSafeString(original: str, fallback: str = "fallback") -> str:

--- a/src/mireport/filesupport.py
+++ b/src/mireport/filesupport.py
@@ -11,7 +11,7 @@ from PIL.Image import Resampling
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-    from typing import BinaryIO, Optional
+    from typing import BinaryIO
 
     from typing_extensions import Buffer
 
@@ -99,7 +99,7 @@ class ReadOnlyNamedBytesIO(NamedBytesIO):
         """Get a read-only view over the contents of the BytesIO object."""
         return super().getbuffer().toreadonly()
 
-    def truncate(self, _: Optional[int] = None) -> int:
+    def truncate(self, _: int | None = None) -> int:
         raise UnsupportedOperation("This BytesIO is read-only")
 
     def writable(self) -> bool:
@@ -178,7 +178,6 @@ class FilelikeAndFileName(NamedTuple):
             raise ValueError(f"Parent directory {parent} does not exist")
 
         path.write_bytes(self.fileContent)
-        return
 
     def saveToDirectory(self, directory: Path) -> None:
         """Saves the file content to the specified directory using @self.filename."""
@@ -188,7 +187,6 @@ class FilelikeAndFileName(NamedTuple):
             raise ValueError(f"Path {directory} is an existing file, not a directory")
 
         self.saveToFilepath(directory / self.filename)
-        return
 
 
 class ImageFileLikeAndFileName(FilelikeAndFileName):
@@ -243,8 +241,8 @@ class ImageFileLikeAndFileName(FilelikeAndFileName):
 
     def as_data_url(
         self,
-        max_width: Optional[int] = None,
-        max_height: Optional[int] = None,
+        max_width: int | None = None,
+        max_height: int | None = None,
     ) -> str:
         """
         Resize and convert a logo image to a base64 data URL suitable for XHTML embedding.

--- a/src/mireport/json.py
+++ b/src/mireport/json.py
@@ -1,9 +1,10 @@
+from collections.abc import Generator
 from importlib.resources import Package, files
 from importlib.resources.abc import Traversable
 from json import loads
-from typing import Any, Generator
+from typing import Any
 
-__all__ = ["getResource", "getObject", "getJsonFiles"]
+__all__ = ["getJsonFiles", "getObject", "getResource"]
 
 
 def getResource(module: Package, filename: str) -> Traversable:

--- a/src/mireport/localise.py
+++ b/src/mireport/localise.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Set
-    from typing import Optional
 
 from babel import Locale, UnknownLocaleError
 from babel.numbers import format_decimal, get_decimal_symbol, get_group_symbol
@@ -65,7 +64,7 @@ def babelIdentifier_to_xmlLang(babelId: str) -> str:
     return babelId.replace("_", "-")
 
 
-def split_base_territory(locale_str: str) -> tuple[str, Optional[str]]:
+def split_base_territory(locale_str: str) -> tuple[str, str | None]:
     """Split a locale string into base language and territory components."""
     locale_str = babelIdentifier_to_xmlLang(locale_str)
     baseLang, _, territory = locale_str.partition("-")
@@ -80,7 +79,7 @@ def argparse_locale(s: str) -> Locale:
         raise argparse.ArgumentTypeError(f"Invalid locale: {s}")
 
 
-def get_locale_from_str(s: str) -> Optional[Locale]:
+def get_locale_from_str(s: str) -> Locale | None:
     """Parse a locale string into a Locale object, normalizing to underscore format. Fallback to None on error."""
     try:
         s = s.replace("-", "_")
@@ -99,7 +98,7 @@ def extract_base_languages(languages: Iterable) -> frozenset[str]:
 
 
 def get_locale_list(
-    requestedCodes: Iterable[str], supportedLanguages: Optional[Set[str]] = None
+    requestedCodes: Iterable[str], supportedLanguages: Set[str] | None = None
 ) -> list[dict[str, str]]:
     locales: list[dict[str, str]] = []
 
@@ -133,9 +132,9 @@ def get_locale_list(
 
 
 def localise_and_format_number(
-    number: float | int | str | Decimal,
+    number: float | str | Decimal,
     decimal_places: DecimalPlaces,
-    locale: Optional[Locale] = None,
+    locale: Locale | None = None,
 ) -> str:
     """
     Format a number with optional locale, supporting 'INF' for unlimited precision.
@@ -180,8 +179,7 @@ def localise_and_format_number(
         return f"{value:,}"
 
     # Handle negative decimal places (fallback to 0)
-    if decimal_places < 0:
-        decimal_places = 0
+    decimal_places = max(decimal_places, 0)
 
     # Normal finite case
     if locale:
@@ -194,7 +192,7 @@ def localise_and_format_number(
         return f"{value:,.{decimal_places}f}"
 
 
-def decimal_symbol(locale: Optional[Locale] = None) -> str:
+def decimal_symbol(locale: Locale | None = None) -> str:
     """Return the decimal symbol for the given locale."""
     if locale:
         return get_decimal_symbol(locale)
@@ -202,7 +200,7 @@ def decimal_symbol(locale: Optional[Locale] = None) -> str:
         return "."
 
 
-def group_symbol(locale: Optional[Locale] = None) -> str:
+def group_symbol(locale: Locale | None = None) -> str:
     """Return the decimal symbol for the given locale."""
     if locale:
         return get_group_symbol(locale)

--- a/src/mireport/localise.py
+++ b/src/mireport/localise.py
@@ -125,7 +125,7 @@ def get_locale_list(
             label = f"{language} ({territory}) [{display_code}]"
 
             locales.append({"code": normalized_code, "label": label})
-        except Exception:
+        except Exception:  # noqa: BLE001 - one bad locale must not lose the rest
             L.exception("Error parsing locale")
             continue
     locales.sort(key=lambda x: x["label"].casefold())

--- a/src/mireport/localise.py
+++ b/src/mireport/localise.py
@@ -6,7 +6,8 @@ from decimal import Decimal
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Set
+    from collections.abc import Iterable
+    from collections.abc import Set as AbstractSet
 
 from babel import Locale, UnknownLocaleError
 from babel.numbers import format_decimal, get_decimal_symbol, get_group_symbol
@@ -98,7 +99,7 @@ def extract_base_languages(languages: Iterable) -> frozenset[str]:
 
 
 def get_locale_list(
-    requestedCodes: Iterable[str], supportedLanguages: Set[str] | None = None
+    requestedCodes: Iterable[str], supportedLanguages: AbstractSet[str] | None = None
 ) -> list[dict[str, str]]:
     locales: list[dict[str, str]] = []
 

--- a/src/mireport/report/fact.py
+++ b/src/mireport/report/fact.py
@@ -14,7 +14,6 @@ from mireport.taxonomy import Concept, QName
 from mireport.typealiases import DecimalPlaces, FactValue
 
 if TYPE_CHECKING:
-    from typing import Optional
 
     from mireport.report.footnote import Footnote
     from mireport.report.inlinereport import InlineReport
@@ -75,7 +74,7 @@ class Fact:
                     dimvalue = self._aspects.pop(key)
                     self._aspects[f"typed {keyConcept.qname}"] = dimvalue
 
-        self._decimals: Optional[DecimalPlaces]
+        self._decimals: DecimalPlaces | None
         if aspect_value := str(self._aspects.get("decimals", "")):
             if aspect_value == "INF":
                 self._decimals = "INF"
@@ -85,7 +84,7 @@ class Fact:
         else:
             self._decimals = None
 
-        self._numeric_scale: Optional[int] = None
+        self._numeric_scale: int | None = None
         if aspect_value := str(self._aspects.get("numeric-scale", "")):
             self._numeric_scale = int(aspect_value)
             self._aspects["numeric-scale"] = f'"{aspect_value}"'

--- a/src/mireport/report/fact.py
+++ b/src/mireport/report/fact.py
@@ -14,7 +14,6 @@ from mireport.taxonomy import Concept, QName
 from mireport.typealiases import DecimalPlaces, FactValue
 
 if TYPE_CHECKING:
-
     from mireport.report.footnote import Footnote
     from mireport.report.inlinereport import InlineReport
 
@@ -198,7 +197,10 @@ class Fact:
 
     @property
     def hasNonDefaultPeriod(self) -> bool:
-        return bool((period := self.aspects.get("period")) is not None and period != self._report._defaultPeriodName)
+        return bool(
+            (period := self.aspects.get("period")) is not None
+            and period != self._report._defaultPeriodName
+        )
 
     @property
     def period(self) -> DurationPeriodHolder | InstantPeriodHolder:

--- a/src/mireport/report/fact.py
+++ b/src/mireport/report/fact.py
@@ -198,11 +198,7 @@ class Fact:
 
     @property
     def hasNonDefaultPeriod(self) -> bool:
-        if (
-            period := self.aspects.get("period")
-        ) is not None and period != self._report._defaultPeriodName:
-            return True
-        return False
+        return bool((period := self.aspects.get("period")) is not None and period != self._report._defaultPeriodName)
 
     @property
     def period(self) -> DurationPeriodHolder | InstantPeriodHolder:

--- a/src/mireport/report/factbuilder.py
+++ b/src/mireport/report/factbuilder.py
@@ -11,7 +11,7 @@ from mireport.typealiases import DecimalPlaces, FactValue
 
 if TYPE_CHECKING:
     from collections.abc import Collection
-    from typing import Optional, Self
+    from typing import Self
 
     from mireport.report.inlinereport import InlineReport
 
@@ -25,9 +25,9 @@ class FactBuilder:
 
     def __init__(self, report: InlineReport):
         self._report: InlineReport = report
-        self._concept: Optional[Concept] = None
+        self._concept: Concept | None = None
         self._aspects: dict[str | QName, str | QName] = {}
-        self._value: Optional[FactValue] = None
+        self._value: FactValue | None = None
 
     def __repr__(self) -> str:
         bits = (self._concept, self._aspects, self._value)
@@ -71,7 +71,7 @@ class FactBuilder:
 
     def setPercentageValue(
         self,
-        value: int | float,
+        value: float,
         decimals: DecimalPlaces,
         *,
         inputIsDecimalForm: bool = True,
@@ -264,7 +264,6 @@ class FactBuilder:
                     explicitDims[dimension] = taxonomy.getConcept(value)
         self.validateTypedDimensions(taxonomy, typedDims)
         self.validateExplicitDimensions(taxonomy, explicitDims)
-        return
 
     def validateTypedDimensions(
         self, taxonomy: Taxonomy, typedDims: dict[Concept, str]

--- a/src/mireport/report/inlinereport.py
+++ b/src/mireport/report/inlinereport.py
@@ -4,14 +4,10 @@ import logging
 import time
 import zipfile
 from collections import defaultdict
-from datetime import date, datetime, timezone
+from datetime import UTC, date, datetime
 from io import BytesIO
 from itertools import count
-from typing import TYPE_CHECKING
 from unicodedata import name as unicode_name
-
-if TYPE_CHECKING:
-    from typing import Optional
 
 import ixbrltemplates
 from babel import Locale
@@ -41,21 +37,21 @@ from mireport.typealiases import FactValue
 
 L = logging.getLogger(__name__)
 
-UNCONSTRAINED_REPORT_PACKAGE_JSON = """{
+UNCONSTRAINED_REPORT_PACKAGE_JSON = b"""{
     "documentInfo": {
         "documentType": "https://xbrl.org/report-package/2023"
     }
-}""".encode("UTF-8")
+}"""
 
-INLINE_REPORT_PACKAGE_JSON = """{
+INLINE_REPORT_PACKAGE_JSON = b"""{
     "documentInfo": {
         "documentType": "https://xbrl.org/report-package/2023/xbri"
     }
-}""".encode("UTF-8")
+}"""
 
 
 class InlineReport:
-    def __init__(self, taxonomy: Taxonomy, outputLocale: Optional[Locale] = None):
+    def __init__(self, taxonomy: Taxonomy, outputLocale: Locale | None = None):
         self._facts: list[Fact] = []
         self._factsByConcept: dict[Concept, list[Fact]] = defaultdict(list)
         self._footnoteCounter: count = count(1)
@@ -63,13 +59,13 @@ class InlineReport:
         self._taxonomy: Taxonomy = taxonomy
         self._periods: dict[str, DurationPeriodHolder] = {}
         self._entityName: str = "Sample"
-        self._generatedReport: Optional[str] = None
+        self._generatedReport: str | None = None
         self._defaultPeriodName: str = ""
         self._schemaRefs: set[str] = set()
         self._reportTitle: str = ""
         self._reportSubtitle: str = ""
-        self._introduction: Optional[str] = None
-        self._backCoverMatter: Optional[str] = None
+        self._introduction: str | None = None
+        self._backCoverMatter: str | None = None
         self._theme: ReportTheme = ReportTheme.default()
         self._footnotesByGroup: dict[str, Footnote] = {}
         self._labelOverrides: dict[str, str] = {}
@@ -259,7 +255,6 @@ class InlineReport:
             )
 
         candidates[0].value = value
-        return
 
     @property
     def hasFacts(self) -> bool:
@@ -299,7 +294,7 @@ class InlineReport:
         def addDict(
             key: str,
             value: str | PeriodHolder | Symbol,
-            format_macro: Optional[str] = None,
+            format_macro: str | None = None,
         ) -> None:
             d: dict[str, str | PeriodHolder | Symbol] = {"key": key, "value": value}
             if format_macro is not None:
@@ -353,7 +348,7 @@ class InlineReport:
             {
                 PresentationStyle.__name__: PresentationStyle,
                 TableStyle.__name__: TableStyle,
-                "now_utc": lambda: datetime.now(timezone.utc),
+                "now_utc": lambda: datetime.now(UTC),
                 "labelLanguage": label_language,
                 "labelQNameFallback": label_language is None,
                 "label_overrides_by_concept": self._labelOverrides,

--- a/src/mireport/report/theme.py
+++ b/src/mireport/report/theme.py
@@ -4,7 +4,7 @@ import logging
 import re
 from dataclasses import dataclass
 from enum import ReprEnum, StrEnum
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
     from typing import Self
@@ -107,9 +107,9 @@ class ReportTheme:
 
     colour: CSSHexColour
     displayMode: DisplayMode
-    background_image: Optional[ImageFileLikeAndFileName] = None
-    cover_image: Optional[ImageFileLikeAndFileName] = None
-    logo_image: Optional[ImageFileLikeAndFileName] = None
+    background_image: ImageFileLikeAndFileName | None = None
+    cover_image: ImageFileLikeAndFileName | None = None
+    logo_image: ImageFileLikeAndFileName | None = None
 
     @classmethod
     def default(cls) -> ReportTheme:

--- a/src/mireport/report/theme.py
+++ b/src/mireport/report/theme.py
@@ -24,7 +24,7 @@ class CSSHexColour(str):
 
     _HEX_RE: ClassVar[re.Pattern[str]] = re.compile(r"#[0-9A-Fa-f]{6}")
 
-    def __new__(cls, value: str) -> CSSHexColour:
+    def __new__(cls, value: str) -> Self:
         if not cls.is_valid(value):
             raise InvalidReportThemeException(
                 f"Colour must be a 6-digit hex code (e.g. #1a2b3c), got '{value}'."

--- a/src/mireport/taxonomy.py
+++ b/src/mireport/taxonomy.py
@@ -380,9 +380,8 @@ class Concept:
         # Perhaps the label is just a unitId
         if (
             qname := self._taxonomy.UTR.getQNameForUnitId(measurementLabel)
-        ) is not None:
-            if qname in allValidUnitQNames:
-                return frozenset({qname})
+        ) is not None and qname in allValidUnitQNames:
+            return frozenset({qname})
 
         # Perhaps the label is just a unit QNAME
         if self._qnameMaker.isValidQName(measurementLabel):
@@ -697,17 +696,17 @@ class Taxonomy:
                 cByPretend[norm_label_no_suffix].append(concept)
                 cByPretend[norm_label_no_suffix_all_lc].append(concept)
 
-        self._lookupConceptsByStandardLabel: dict[str, frozenset[Concept]] = dict(
-            (k, frozenset(v)) for k, v in cByStdLbl.items()
-        )
-        self._lookupConceptsByPretendLabel: dict[str, frozenset[Concept]] = dict(
-            (k, frozenset(v)) for k, v in cByPretend.items()
-        )
+        self._lookupConceptsByStandardLabel: dict[str, frozenset[Concept]] = {
+            k: frozenset(v) for k, v in cByStdLbl.items()
+        }
+        self._lookupConceptsByPretendLabel: dict[str, frozenset[Concept]] = {
+            k: frozenset(v) for k, v in cByPretend.items()
+        }
 
-        self._dimensionDefaults: Mapping[Concept, Concept] = dict(
-            (self.getConcept(dimension), self.getConcept(domainMember))
+        self._dimensionDefaults: Mapping[Concept, Concept] = {
+            self.getConcept(dimension): self.getConcept(domainMember)
             for dimension, domainMember in dimensions.pop("_defaults", {}).items()
-        )
+        }
 
         self._baseSets: dict[BaseSet, list[dict]] = defaultdict(list)
         self._lookupBaseSetByCube: dict[Concept, list[BaseSet]] = defaultdict(list)
@@ -719,7 +718,7 @@ class Taxonomy:
         domainByDimension: dict[Concept, list[Concept]] = defaultdict(list)
 
         for role, cubes in dimensions.items():
-            cubeConcepts = frozenset(concepts[c] for c in cubes.keys())
+            cubeConcepts = frozenset(concepts[c] for c in cubes)
             baseSet = BaseSet(role, cubeConcepts)
             for cubeQname, cubeDetails in cubes.items():
                 hc_concept = concepts[cubeQname]
@@ -766,7 +765,7 @@ class Taxonomy:
             for dimension, domainlist in domainByDimension.items()
         }
         self._hypercubes = frozenset(
-            c for x in self._baseSets.keys() for c in x.hyperCubes
+            c for x in self._baseSets for c in x.hyperCubes
         )
 
         if open_hcs:
@@ -924,7 +923,7 @@ class Taxonomy:
             ed
             for b in baseSets
             for cube in self._baseSets[b]
-            for ed in cube["explicitDimensions"].keys()
+            for ed in cube["explicitDimensions"]
         }
         return frozenset(explicit)
 
@@ -936,7 +935,7 @@ class Taxonomy:
         dims: list[Concept] = []
         for b in baseSets:
             for cube in self._baseSets[b]:
-                dims.extend(ed for ed in cube["explicitDimensions"].keys())
+                dims.extend(ed for ed in cube["explicitDimensions"])
                 dims.extend(td for td in cube["typedDimensions"])
         return frozenset(dims)
 
@@ -1033,7 +1032,7 @@ class Taxonomy:
         counts.update(
             lang.lower()
             for concept in self._concepts.values()
-            for lang in concept._labels.keys()
+            for lang in concept._labels
         )
         return counts
 

--- a/src/mireport/taxonomy.py
+++ b/src/mireport/taxonomy.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, NamedTuple, overload
 from mireport.data import registries, taxonomies
 from mireport.exceptions import (
     AmbiguousComponentException,
+    BrokenQNameException,
     TaxonomyException,
     UnknownTaxonomyException,
 )
@@ -37,6 +38,8 @@ from mireport.xml import (
 
 if TYPE_CHECKING:
     from typing import Any, Self
+
+L = logging.getLogger(__name__)
 
 MEASUREMENT_GUIDANCE_LABEL_ROLE = "http://www.xbrl.org/2003/role/measurementGuidance"
 STANDARD_LABEL_ROLE = "http://www.xbrl.org/2003/role/label"
@@ -824,7 +827,7 @@ class Taxonomy:
                 concept = self.getConcept(text)
                 if not only_reportable or concept.isReportable:
                     return concept
-            except Exception:
+            except (BrokenQNameException, KeyError):
                 pass  # not a valid QName format or concept not present
 
         candidates: set[Concept] = set()
@@ -1086,8 +1089,8 @@ def loadBuiltInTaxonomyJSON() -> None:
     for f in getJsonFiles(taxonomies):
         try:
             _createTaxonomyFromJSON(getObject(f))
-        except Exception as e:
-            logging.error(f"Error loading taxonomy from {f.name}", exc_info=e)
+        except Exception as e:  # noqa: BLE001 - one bad file must not lose the rest
+            L.error(f"Error loading taxonomy from {f.name}", exc_info=e)
 
 
 def _createTaxonomyFromJSON(bits: dict) -> None:

--- a/src/mireport/taxonomy.py
+++ b/src/mireport/taxonomy.py
@@ -357,7 +357,9 @@ class Concept:
             for role_uri in lang_labels
         )
 
-    @cache
+    # N.B. B019 (cache keeps `self` alive) is not a concern: Concepts belong to a
+    # Taxonomy which is kept in a module level registry for the life of the process.
+    @cache  # noqa: B019
     def getRequiredUnitQNames(self) -> frozenset[QName] | None:
         """If there is a valid UTR unitId or a valid unit QName in the
         measurement guidance label of the concept, return the first one found.
@@ -928,7 +930,7 @@ class Taxonomy:
         }
         return frozenset(explicit)
 
-    @cache
+    @cache  # noqa: B019 - Taxonomy lives for the life of the process. See above.
     def getDimensionsForHypercube(self, hypercube: Concept) -> frozenset[Concept]:
         baseSets = self._lookupBaseSetByCube.get(hypercube)
         if baseSets is None:
@@ -973,7 +975,7 @@ class Taxonomy:
         tds = {td for hc in hcs for td in self.getTypedDimensionsForHypercube(hc)}
         return frozenset(tds)
 
-    @cache
+    @cache  # noqa: B019 - Taxonomy lives for the life of the process. See above.
     def getExplicitDimensionForDomainMember(
         self, primaryItem: Concept, dimensionValue: Concept
     ) -> Concept | None:

--- a/src/mireport/taxonomy.py
+++ b/src/mireport/taxonomy.py
@@ -764,9 +764,7 @@ class Taxonomy:
             dimension: frozenset(domainlist)
             for dimension, domainlist in domainByDimension.items()
         }
-        self._hypercubes = frozenset(
-            c for x in self._baseSets for c in x.hyperCubes
-        )
+        self._hypercubes = frozenset(c for x in self._baseSets for c in x.hyperCubes)
 
         if open_hcs:
             # Not supported by mireport (aoix doesn't care)

--- a/src/mireport/taxonomy.py
+++ b/src/mireport/taxonomy.py
@@ -36,7 +36,7 @@ from mireport.xml import (
 )
 
 if TYPE_CHECKING:
-    from typing import Any, Optional, Self
+    from typing import Any, Self
 
 MEASUREMENT_GUIDANCE_LABEL_ROLE = "http://www.xbrl.org/2003/role/measurementGuidance"
 STANDARD_LABEL_ROLE = "http://www.xbrl.org/2003/role/label"
@@ -95,21 +95,21 @@ class Concept:
     """
 
     __slots__ = (
-        "qname",
-        "periodType",
-        "dataType",
-        "baseDataType",
-        "typedElement",
-        "_labels",
+        "_eeDomainMemberStrings",
+        "_eeDomainMembers",
         "_isAbstract",
         "_isDimension",
         "_isHypercube",
         "_isNillable",
         "_isNumeric",
-        "_eeDomainMembers",
-        "_eeDomainMemberStrings",
+        "_labels",
         "_qnameMaker",
         "_taxonomy",
+        "baseDataType",
+        "dataType",
+        "periodType",
+        "qname",
+        "typedElement",
     )
 
     def __init__(self, qnameMaker: QNameMaker, s_qname: str, details: dict):
@@ -151,8 +151,8 @@ class Concept:
         if (tElem := other.get("typedElement")) is not None:
             self.typedElement = self._qnameMaker.fromString(tElem)
 
-        self._eeDomainMembers: Optional[tuple[Concept, ...]] = None
-        self._eeDomainMemberStrings: Optional[list[str]] = None
+        self._eeDomainMembers: tuple[Concept, ...] | None = None
+        self._eeDomainMemberStrings: list[str] | None = None
         if (eeDom := other.get("ee20DomainMembers")) is not None:
             self._eeDomainMemberStrings = eeDom
 
@@ -193,12 +193,12 @@ class Concept:
     def getLabelForRole(
         self,
         roleUri: str,
-        requestedLanguage: Optional[str] = None,
-        fallbackLabel: Optional[str] = None,
+        requestedLanguage: str | None = None,
+        fallbackLabel: str | None = None,
         fallbackToAnyLang: bool = False,
         fallbackToQName: bool = False,
         removeSuffix: bool = False,
-    ) -> Optional[str]:
+    ) -> str | None:
         """Return the label for *roleUri* in the requested language."""
         if (defaultLanguage := self._taxonomy.defaultLanguage) is None:
             return None
@@ -251,7 +251,7 @@ class Concept:
     @overload
     def getStandardLabel(
         self,
-        lang: Optional[str] = None,
+        lang: str | None = None,
         *,
         fallbackIfMissing: str,
         removeSuffix: bool = ...,
@@ -262,23 +262,23 @@ class Concept:
     @overload
     def getStandardLabel(
         self,
-        lang: Optional[str] = None,
+        lang: str | None = None,
         *,
         fallbackIfMissing: None = None,
         removeSuffix: bool = ...,
         fallbackToAnyLang: bool = ...,
         fallbackToQName: bool = ...,
-    ) -> Optional[str]: ...
+    ) -> str | None: ...
 
     def getStandardLabel(
         self,
-        lang: Optional[str] = None,
+        lang: str | None = None,
         *,
-        fallbackIfMissing: Optional[str] = None,
+        fallbackIfMissing: str | None = None,
         removeSuffix: bool = False,
         fallbackToAnyLang: bool = False,
         fallbackToQName: bool = False,
-    ) -> Optional[str]:
+    ) -> str | None:
         return self.getLabelForRole(
             STANDARD_LABEL_ROLE,
             requestedLanguage=lang,
@@ -290,13 +290,13 @@ class Concept:
 
     def getDocumentationLabel(
         self,
-        lang: Optional[str] = None,
+        lang: str | None = None,
         *,
-        fallbackIfMissing: Optional[str] = None,
+        fallbackIfMissing: str | None = None,
         removeSuffix: bool = False,
         fallbackToAnyLang: bool = False,
         fallbackToQName: bool = False,
-    ) -> Optional[str]:
+    ) -> str | None:
         return self.getLabelForRole(
             DOCUMENTATION_LABEL_ROLE,
             requestedLanguage=lang,
@@ -308,8 +308,8 @@ class Concept:
 
     def _getLabelIterable(
         self,
-        labelRole: Optional[str] = None,
-        lang: Optional[str] = None,
+        labelRole: str | None = None,
+        lang: str | None = None,
     ) -> Iterable[str]:
         """
         Yield labels for this concept, optionally filtered by role and/or language.
@@ -355,7 +355,7 @@ class Concept:
         )
 
     @cache
-    def getRequiredUnitQNames(self) -> Optional[frozenset[QName]]:
+    def getRequiredUnitQNames(self) -> frozenset[QName] | None:
         """If there is a valid UTR unitId or a valid unit QName in the
         measurement guidance label of the concept, return the first one found.
         Otherwise return None.
@@ -499,17 +499,17 @@ class Relationship(NamedTuple):
     roleUri: str
     depth: int
     concept: Concept
-    preferredLabel: Optional[str] = None
+    preferredLabel: str | None = None
 
     def getLabel(
         self,
-        requestedLanguage: Optional[str] = None,
+        requestedLanguage: str | None = None,
         *,
         removeSuffix: bool = True,
-        fallbackLabel: Optional[str] = None,
+        fallbackLabel: str | None = None,
         fallbackToAnyLang: bool = False,
         fallbackToQName: bool = False,
-    ) -> Optional[str]:
+    ) -> str | None:
         """Get the label for this relationship's concept."""
         labelRole = self.preferredLabel or STANDARD_LABEL_ROLE
         return self.concept.getLabelForRole(
@@ -565,7 +565,7 @@ class PresentationGroup(NamedTuple):
 
     def getLabel(
         self,
-        requestedLanguage: Optional[str] = None,
+        requestedLanguage: str | None = None,
         *,
         fallbackToDefaultLanguage: bool = True,
         fallbackToDefinition: bool = True,
@@ -807,7 +807,7 @@ class Taxonomy:
         by_name: bool = False,
         by_qname: bool = False,
         only_reportable: bool = True,
-    ) -> Optional[Concept]:
+    ) -> Concept | None:
         """Resolve a string to a Concept using one or more strategies.
 
         Strategies are tried in specificity order: qname → name → label.
@@ -875,7 +875,7 @@ class Taxonomy:
             name, by_name=True, by_label=False, by_qname=False, only_reportable=False
         )
 
-    def getConceptForLabel(self, label: str) -> Optional[Concept]:
+    def getConceptForLabel(self, label: str) -> Concept | None:
         return self.resolveConcept(
             label, by_label=True, by_name=False, by_qname=False, only_reportable=False
         )
@@ -976,7 +976,7 @@ class Taxonomy:
     @cache
     def getExplicitDimensionForDomainMember(
         self, primaryItem: Concept, dimensionValue: Concept
-    ) -> Optional[Concept]:
+    ) -> Concept | None:
         baseSets = self._lookupBaseSetByPrimaryItem.get(primaryItem)
         if baseSets is None:
             return None
@@ -1002,7 +1002,7 @@ class Taxonomy:
         """This aggregates across all base-sets to give all the domain members specified for the given dimension."""
         return self._lookupDomainByDimension.get(dimension, frozenset())
 
-    def getDimensionDefault(self, dimension: Concept) -> Optional[Concept]:
+    def getDimensionDefault(self, dimension: Concept) -> Concept | None:
         return self._dimensionDefaults.get(dimension)
 
     @cached_property

--- a/src/mireport/taxonomy_checker.py
+++ b/src/mireport/taxonomy_checker.py
@@ -78,13 +78,12 @@ class TaxonomyChecker:
                             actual = labelsByRole.get(STANDARD_LABEL_ROLE)
                             if actual is None:
                                 continue
-                            if actual == bad_label:
+                            if actual == bad_label or (
+                                label_transforms
+                                and bad_label
+                                in _apply_transforms(actual, label_transforms)
+                            ):
                                 lang_codes.append(lang)
-                            elif label_transforms:
-                                if bad_label in _apply_transforms(
-                                    actual, label_transforms
-                                ):
-                                    lang_codes.append(lang)
                     unique_langs = set(lang_codes)
                     if len(unique_langs) == 1:
                         langs_for_label[bad_label] = next(iter(unique_langs))

--- a/src/mireport/taxonomy_checker.py
+++ b/src/mireport/taxonomy_checker.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Callable, Sequence
+from collections.abc import Callable, Sequence
 
 from mireport.stringutil import normalizeLabelText, stripLabelSuffix
 from mireport.taxonomy import STANDARD_LABEL_ROLE, Concept, Taxonomy

--- a/src/mireport/typealiases.py
+++ b/src/mireport/typealiases.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import date, datetime
-from typing import Literal, Mapping
+from typing import Literal
 
 DecimalPlaces = int | Literal["INF"]
 FactValue = int | float | bool | str | date | datetime

--- a/src/mireport/utr.py
+++ b/src/mireport/utr.py
@@ -5,7 +5,7 @@ from functools import cache, cached_property
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Optional, Self
+    from typing import Self
 
 from mireport.exceptions import UnitException
 from mireport.xml import ISO4217_NS, XBRLI_NS, QName, QNameMaker
@@ -58,7 +58,7 @@ class UTR:
         return cls(unitToNamespaces, dataTypeToUnit, unitQNamesToEntries, qnameMaker)
 
     @cache
-    def getQNameForUnitId(self, unitId: str) -> Optional[QName]:
+    def getQNameForUnitId(self, unitId: str) -> QName | None:
         if self._qnameMaker.isValidQName(unitId):
             return self._qnameMaker.fromString(unitId)
         namespaces = self._lookupNamespacesByUnitId.get(unitId)

--- a/src/mireport/utr.py
+++ b/src/mireport/utr.py
@@ -57,7 +57,9 @@ class UTR:
 
         return cls(unitToNamespaces, dataTypeToUnit, unitQNamesToEntries, qnameMaker)
 
-    @cache
+    # N.B. B019 (cache keeps `self` alive) is not a concern: a UTR belongs to a
+    # Taxonomy which is kept in a module level registry for the life of the process.
+    @cache  # noqa: B019
     def getQNameForUnitId(self, unitId: str) -> QName | None:
         if self._qnameMaker.isValidQName(unitId):
             return self._qnameMaker.fromString(unitId)
@@ -72,7 +74,7 @@ class UTR:
             namespace=namespaces[0], localName=unitId
         )
 
-    @cache
+    @cache  # noqa: B019 - UTR lives for the life of the process. See above.
     def getUnitsForDataType(self, dataType: QName) -> frozenset[QName]:
         """Get the unit IDs for a given data type."""
         possible = self._lookupUnitIdByDataType.get(dataType)
@@ -86,7 +88,7 @@ class UTR:
             )
         return frozenset()
 
-    @cache
+    @cache  # noqa: B019 - UTR lives for the life of the process. See above.
     def getUnitIdsForDataType(self, dataType: QName) -> frozenset[str]:
         """Get the unit ID for a given data type."""
         possible: list[str] = []

--- a/src/mireport/xlsx_template_reader/_util.py
+++ b/src/mireport/xlsx_template_reader/_util.py
@@ -1,15 +1,13 @@
 import re
 import warnings
+from collections.abc import Iterator
 from datetime import date, datetime, time
 from pathlib import Path
 from typing import (
     BinaryIO,
-    Iterator,
     Literal,
     NamedTuple,
-    Optional,
     TypeAlias,
-    Union,
     overload,
 )
 
@@ -96,8 +94,8 @@ def excelCellOrCellRangeRef(
 
 
 def excelDefinedNameRef(
-    definedName: Optional[DefinedName], cell: Optional[CellType] = None
-) -> Optional[str]:
+    definedName: DefinedName | None, cell: CellType | None = None
+) -> str | None:
     """Make an Excel cell reference such as 'Example sheet'!$A$5"""
     if definedName is None:
         return None
@@ -235,8 +233,8 @@ def get_decimal_places(cell: CellType) -> DecimalPlaces:
 def getCellRangeIterator(
     ws: Worksheet,
     cr: CellRange,
-    row_start: Optional[int] = None,
-    col_start: Optional[int] = None,
+    row_start: int | None = None,
+    col_start: int | None = None,
     group_by_row: Literal[False] = False,
 ) -> Iterator[tuple[int, int, CellType]]: ...
 
@@ -245,8 +243,8 @@ def getCellRangeIterator(
 def getCellRangeIterator(
     ws: Worksheet,
     cr: CellRange,
-    row_start: Optional[int] = None,
-    col_start: Optional[int] = None,
+    row_start: int | None = None,
+    col_start: int | None = None,
     group_by_row: Literal[True] = True,
 ) -> Iterator[tuple[int, tuple[CellType, ...]]]: ...
 
@@ -254,10 +252,10 @@ def getCellRangeIterator(
 def getCellRangeIterator(
     ws: Worksheet,
     cr: CellRange,
-    row_start: Optional[int] = None,
-    col_start: Optional[int] = None,
+    row_start: int | None = None,
+    col_start: int | None = None,
     group_by_row: bool = False,
-) -> Iterator[Union[tuple[int, int, CellType], tuple[int, tuple[CellType, ...]]]]:
+) -> Iterator[tuple[int, int, CellType] | tuple[int, tuple[CellType, ...]]]:
     """Iterates over cells in the given range, supporting both standard and row-grouped modes."""
 
     if cr.min_row is None or cr.min_col is None:
@@ -332,9 +330,8 @@ def getEffectiveCellRangeDimensions(
             cols_not_empty.add(cnum)
         else:
             cols_empty.add(cnum)
-    else:
-        if not empty_row:
-            populated_rows.add(rnum)
+    if not empty_row:
+        populated_rows.add(rnum)
 
     definitely_empty_cols = cols_empty - cols_not_empty
     total_cols = len(cols_not_empty.union(cols_empty))

--- a/src/mireport/xlsx_template_reader/_util.py
+++ b/src/mireport/xlsx_template_reader/_util.py
@@ -48,7 +48,7 @@ def checkExcelFilePath(path: Path) -> None:
     if not path.is_file():
         raise FileNotFoundError(f'"{path}" is not a file.')
     elif path.suffix != ".xlsx":
-        raise Exception(f'"{path}" is not a supported (.xlsx) Excel file')
+        raise ValueError(f'"{path}" is not a supported (.xlsx) Excel file')
 
 
 def loadExcelFromPathOrFileLike(

--- a/src/mireport/xlsx_template_reader/processor.py
+++ b/src/mireport/xlsx_template_reader/processor.py
@@ -13,7 +13,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
-    from typing import BinaryIO, Callable, Optional, Self
+    from collections.abc import Callable
+    from typing import BinaryIO, Self
 
 from babel import Locale
 from dateutil.parser import parse as parse_datetime
@@ -111,7 +112,7 @@ def eeDomainByLabel(eeConcept: Concept) -> dict[str, tuple[Concept, str]]:
 
 def getClosestEEMemberMatch(
     eeConcept: Concept, text: str
-) -> Optional[tuple[Concept, str]]:
+) -> tuple[Concept, str] | None:
     eeDomainLabels = eeDomainByLabel(eeConcept)
     closest_matches = difflib.get_close_matches(
         text, eeDomainLabels.keys(), n=1, cutoff=0.6
@@ -194,7 +195,7 @@ class ExcelProcessor:
         results: ConversionResultsBuilder,
         defaults: dict,
         /,
-        outputLocale: Optional[Locale] = None,
+        outputLocale: Locale | None = None,
     ):
         self._results = results
         self._defaults = defaults
@@ -217,8 +218,8 @@ class ExcelProcessor:
         self._tableRelatedNames: dict[CellAndXBRLMetadataHolder, TableXBRLContents] = {}
 
         # For passing through to inline report
-        self._outputLocale: Optional[Locale] = outputLocale
-        self._coverImage: Optional[bytes] = None
+        self._outputLocale: Locale | None = outputLocale
+        self._coverImage: bytes | None = None
 
         # Not yet initialised. Need setting early
         self._workbook: Workbook
@@ -289,7 +290,7 @@ class ExcelProcessor:
             if dn.name and not dn.name.startswith(("enum_", "footnote_", "template_"))
         )
 
-    def getDefinedNameForString(self, name: str) -> Optional[DefinedName]:
+    def getDefinedNameForString(self, name: str) -> DefinedName | None:
         """
         Get the DefinedName for a given name string or None if it is not present.
         """
@@ -612,7 +613,7 @@ class ExcelProcessor:
         )
 
     @classmethod
-    def checkReport(cls, excelBlob: BinaryIO) -> Optional[TemplateCheckResult]:
+    def checkReport(cls, excelBlob: BinaryIO) -> TemplateCheckResult | None:
         """
         Check the report template for internal validation and version information.
         """
@@ -695,7 +696,7 @@ class ExcelProcessor:
         *,
         row: int = -1,
         column: int = -1,
-    ) -> Optional[CellType]:
+    ) -> CellType | None:
         if isinstance(definedName, str):
             definedName = self._workbook.defined_names.get(definedName)
             if definedName is None:
@@ -842,7 +843,7 @@ class ExcelProcessor:
 
     def getSimpleUnit(
         self, unitHolder: CellAndXBRLMetadataHolder, cell: CellType
-    ) -> Optional[QName]:
+    ) -> QName | None:
         if not cell.value:
             return None
         cellValue = str(cell.value).strip()
@@ -957,7 +958,7 @@ class ExcelProcessor:
             MessageType.ExcelParsing,
         )
 
-    def _getCellRange(self, dn: DefinedName) -> Optional[CellRangeMetadata]:
+    def _getCellRange(self, dn: DefinedName) -> CellRangeMetadata | None:
         try:
             all_destinations = list(dn.destinations)
         except AttributeError:
@@ -1186,7 +1187,6 @@ class ExcelProcessor:
                         periodHolder.worksheet, periodHolder.cellRange
                     ),
                 )
-        return
 
     def createTableFacts(self) -> None:
         for tableStuff, table_contents in self._tableRelatedNames.items():
@@ -1463,13 +1463,13 @@ class ExcelProcessor:
         factBuilder: FactBuilder,
         *,
         row: int = -1,
-        specifiedUnitHolder: Optional[CellAndXBRLMetadataHolder] = None,
-        sharedRange: Optional[bool] = None,
+        specifiedUnitHolder: CellAndXBRLMetadataHolder | None = None,
+        sharedRange: bool | None = None,
     ) -> bool:
         concept = conceptHolder.concept
         # See if we have a {conceptName}_unit named range with a cell value that
         # is a valid unit.
-        unitHolder: Optional[CellAndXBRLMetadataHolder]
+        unitHolder: CellAndXBRLMetadataHolder | None
         if specifiedUnitHolder is not None:
             unitHolder = specifiedUnitHolder
         else:
@@ -1707,7 +1707,7 @@ class ExcelProcessor:
                     if defaultValue is None or dimValue != defaultValue:
                         fb.setExplicitDimension(dim, dimValue)
 
-                    dimValueDN: Optional[DefinedName] = None
+                    dimValueDN: DefinedName | None = None
                     if (
                         dimValueDN := self._workbook.defined_names.get(
                             dimValue.qname.localName
@@ -1863,7 +1863,6 @@ class ExcelProcessor:
                 " ".join(sorted(e.expandedName for e in eeSetValue))
             ).setValue("\n".join(value))
             self.addFactToReport(fb, stuff)
-        return None
 
     def setFallbackUnitForName(
         self, dn: DefinedName, concept: Concept, factBuilder: FactBuilder
@@ -1906,7 +1905,7 @@ class ExcelProcessor:
         stuff: CellAndXBRLMetadataHolder,
         cell: CellType,
         fb: FactBuilder,
-        value: Optional[object] = None,
+        value: object | None = None,
     ) -> None:
         if value is None:
             if cell.value is None:

--- a/src/mireport/xlsx_template_reader/processor.py
+++ b/src/mireport/xlsx_template_reader/processor.py
@@ -97,7 +97,7 @@ def eeDomainByLabel(eeConcept: Concept) -> dict[str, tuple[Concept, str]]:
             f"Concept {eeConcept} with data-type {eeConcept.dataType} is not of enumeration type."
         )
 
-    eeDomainLabels: dict[str, tuple[Concept, str]] = dict()
+    eeDomainLabels: dict[str, tuple[Concept, str]] = {}
     for eeConcept in eeConcept.getEEDomain():
         all_labels = eeConcept.getAllStandardLabels()
         for actual_label in all_labels:
@@ -1071,7 +1071,7 @@ class ExcelProcessor:
 
             candidates: list[CellAndXBRLMetadataHolder] = []
             extras_in_excel: set[CellAndXBRLMetadataHolder] = set()
-            for _, stuff in self._definedNameToXBRLMap.items():
+            for stuff in self._definedNameToXBRLMap.values():
                 concept = stuff.concept
                 if not (concept.isReportable or concept.isDimension):
                     continue
@@ -1341,7 +1341,7 @@ class ExcelProcessor:
                                     ),
                                 )
                         factBuilder.setHiddenValue(
-                            " ".join(sorted(set(e.expandedName for e in eeValues)))
+                            " ".join(sorted({e.expandedName for e in eeValues}))
                         )
 
                     if broken:
@@ -1830,8 +1830,8 @@ class ExcelProcessor:
                     excel_reference=excelCellRef(stuff.worksheet, cell),
                 )
         if EE_SET_DESIRED_EMPTY_PLACEHOLDER_VALUE in value:
-            onlyPlaceholder = set([EE_SET_DESIRED_EMPTY_PLACEHOLDER_VALUE])
-            otherValues = set(x for x in value if x is not None).difference(
+            onlyPlaceholder = {EE_SET_DESIRED_EMPTY_PLACEHOLDER_VALUE}
+            otherValues = {x for x in value if x is not None}.difference(
                 onlyPlaceholder
             )
             if otherValues:

--- a/src/mireport/xlsx_template_reader/processor.py
+++ b/src/mireport/xlsx_template_reader/processor.py
@@ -98,10 +98,10 @@ def eeDomainByLabel(eeConcept: Concept) -> dict[str, tuple[Concept, str]]:
         )
 
     eeDomainLabels: dict[str, tuple[Concept, str]] = {}
-    for eeConcept in eeConcept.getEEDomain():
-        all_labels = eeConcept.getAllStandardLabels()
+    for member in eeConcept.getEEDomain():
+        all_labels = member.getAllStandardLabels()
         for actual_label in all_labels:
-            result = (eeConcept, actual_label)
+            result = (member, actual_label)
             eeDomainLabels[actual_label] = result
 
             # difflib matching works better if we strip the [member] suffix
@@ -638,13 +638,11 @@ class ExcelProcessor:
         If report has not been opened and saved (so, refreshed), formula cells return None.
         template_migration_status is a formula cell.
         """
-        if self._workbook.defined_names.get("template_migration_status") is not None:
-            if self.getSingleValue("template_migration_status") is None:
-                return False  # not refreshed
-            else:
-                return True  # okay
-        else:
+        if self._workbook.defined_names.get("template_migration_status") is None:
             return None
+        # No value means the formula cell has not been recalculated, i.e. the
+        # workbook has not been opened and saved since being migrated.
+        return self.getSingleValue("template_migration_status") is not None
 
     def abortEarlyIfErrors(self) -> None:
         if self._results.hasErrors():
@@ -1872,10 +1870,11 @@ class ExcelProcessor:
             return False
 
         # If we have a default unit for the data type, use it iff UTR valid.
-        if (unit := self._configDataTypeToUnitMap.get(concept.dataType)) is not None:
-            if self.taxonomy.UTR.valid(concept.dataType, unit):
-                factBuilder.setSimpleUnit(unit)
-                return True
+        if (
+            unit := self._configDataTypeToUnitMap.get(concept.dataType)
+        ) is not None and self.taxonomy.UTR.valid(concept.dataType, unit):
+            factBuilder.setSimpleUnit(unit)
+            return True
 
         # Otherwise pick the first unit from the UTR that is valid.
         if units := self.taxonomy.UTR.getUnitsForDataType(concept.dataType):

--- a/src/mireport/xml.py
+++ b/src/mireport/xml.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
-    from typing import Any
 
 from mireport.exceptions import BrokenNamespacePrefixException, BrokenQNameException
 
@@ -131,7 +130,7 @@ class QName:
     def __hash__(self) -> int:
         return hash(self.__key())
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if self is other:
             return True
         if isinstance(other, QName):
@@ -178,7 +177,6 @@ class QNameMaker:
             raise BrokenQNameException(
                 f"QName local name {q.localName} does not look like an NCName."
             )
-        return None
 
     def isValidQName(self, /, qname: str) -> bool:
         try:

--- a/tests/integrationTests/test_expectedFactCounts.py
+++ b/tests/integrationTests/test_expectedFactCounts.py
@@ -45,6 +45,7 @@ def parsed_reports(
             ],
             capture_output=True,
             encoding="utf-8",
+            check=False,
         )
 
         assert result.returncode == 0, (
@@ -95,6 +96,7 @@ def test_validation(parsed_reports: dict[str, Path], input_file: str, _: int) ->
         ],
         capture_output=True,
         encoding="utf-8",
+        check=False,
     )
 
     assert validate_result.returncode == 0, (

--- a/tests/integrationTests/test_expectedFactCounts.py
+++ b/tests/integrationTests/test_expectedFactCounts.py
@@ -1,7 +1,8 @@
 import subprocess
 import sys
+from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 
 import pytest
 from lxml import etree

--- a/tests/unitTests/test_conversionresults.py
+++ b/tests/unitTests/test_conversionresults.py
@@ -46,9 +46,8 @@ def test_processing_context_failure(builder):
     class TestError(Exception):
         pass
 
-    with pytest.raises(TestError):
-        with builder.processingContext("Fail Test"):
-            raise TestError("Fail")
+    with pytest.raises(TestError), builder.processingContext("Fail Test"):
+        raise TestError("Fail")
     msgs = [m for m in builder.messages if m.severity == Severity.ERROR]
     assert any("finished abnormally" in m.messageText for m in msgs)
 

--- a/tests/unitTests/test_conversionresults.py
+++ b/tests/unitTests/test_conversionresults.py
@@ -290,9 +290,11 @@ def test_console_processing_context_early_abort_is_swallowed(builder_with_consol
 
 
 def test_processing_context_unexpected_exception(builder_with_console):
-    with pytest.raises(ValueError):
-        with builder_with_console.processingContext("Fails Hard") as ctx:
-            raise ValueError("Unexpected")
+    with (
+        pytest.raises(ValueError),
+        builder_with_console.processingContext("Fails Hard") as ctx,
+    ):
+        raise ValueError("Unexpected")
 
     # Message should be logged with Severity.ERROR
     messages = builder_with_console.getMessages()

--- a/tests/unitTests/test_filesupport.py
+++ b/tests/unitTests/test_filesupport.py
@@ -328,9 +328,11 @@ class TestFilelikeAndFileName:
 
     def test_saveToFilepath_invalid_filename(self) -> None:
         file_obj = FilelikeAndFileName(b"data", "valid.txt")
-        with tempfile.TemporaryDirectory() as temp_dir:
-            with pytest.raises(ValueError, match="is not valid"):
-                file_obj.saveToFilepath(Path(temp_dir) / "CON")
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            pytest.raises(ValueError, match="is not valid"),
+        ):
+            file_obj.saveToFilepath(Path(temp_dir) / "CON")
 
     def test_saveToDirectory_file_extension_in_path(self) -> None:
         content = b"Extension test"

--- a/tests/unitTests/test_layout.py
+++ b/tests/unitTests/test_layout.py
@@ -615,7 +615,7 @@ class TestAssembleDimsAsRowsTable:
         assert member_a in matrix.row_labels
 
     def test_empty_rows_excluded(self):
-        explicit_dim, domain, reportable, _, member_a, member_b = self._setup()
+        explicit_dim, domain, reportable, _, _, member_b = self._setup()
         # member_b has no facts
         concept_x = reportable[0]
         concept_y = reportable[1]
@@ -671,7 +671,7 @@ class TestAssembleTypedDimTable:
         assert matrix.row_heading_label is typed_dim
 
     def test_rows_sorted_numerically(self):
-        typed_dim, reportable, facts_map, val_2, val_10 = self._setup()
+        typed_dim, reportable, facts_map, _, _ = self._setup()
         o = _organiser(facts_by_concept=facts_map)
         matrix = o._assemble_typed_dim("[B01.test", [typed_dim], reportable)
         assert len(matrix.data) == 2
@@ -679,7 +679,7 @@ class TestAssembleTypedDimTable:
         assert matrix.row_labels[1] == "10"
 
     def test_empty_rows_excluded(self):
-        typed_dim, reportable, facts_map, val_2, val_10 = self._setup()
+        typed_dim, reportable, facts_map, val_2, _ = self._setup()
         concept_x, concept_y = reportable
         typed_qname = f"typed {typed_dim.qname}"
         fact_x2 = _fact(aspects={typed_qname: val_2}, concept=concept_x)

--- a/tests/unitTests/test_localise.py
+++ b/tests/unitTests/test_localise.py
@@ -31,7 +31,7 @@ def test_finite_decimal_places_no_locale(number, decimal_places, expected):
         (Decimal("1234.5678900"), "1,234.5678900"),
         ("1234.5678900", "1,234.5678900"),
         (1234, "1,234"),  # integer
-        (Decimal("1234"), "1,234"),
+        (Decimal(1234), "1,234"),
         (0.000123, "0.000123"),
         ("1e-6", "0.000001"),  # scientific notation expanded
         (Decimal("1e-6"), "0.000001"),

--- a/tests/unitTests/xlsx_template_reader/test_util.py
+++ b/tests/unitTests/xlsx_template_reader/test_util.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 from openpyxl import Workbook


### PR DESCRIPTION
- **[Ruff 0.16 related fixes ...]**
- **[Ruff 0.16 related fixes ...] Refactor code for improved readability and performance by simplifying list comprehensions and dictionary initializations across multiple scripts.**
- **[Ruff 0.16 related fixes ...] Refactor code for improved readability and formatting consistency**
- **[Ruff 0.16 related fixes ...] Fix tests to avoid nesting with and explicitly set check = False on subprocess calls (we handle them manually)**
- **[Ruff 0.16 related fixes ...] Remove unused import of timezone from datetime module**
- **Refactor label collision logic and improve EEDomain handling in processor**
- **[Ruff 0.16 related fixes ...] Enhance type hints for message filtering in ConversionResults and improve argument defaults**
- **[Ruff 0.16 related fixes ...] Enhance error handling and logging across multiple modules; update exception types and add per-file ignores for Ruff linting**
- **Enhance caching and data handling in taxonomy and UTR modules; refactor dataclass usage in TaxonomyInfoPluginData**
