### PR TITLE
Fix InvalidOperation when formatting very large numbers with a locale

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,14 @@ exclude = [
     "^tests/",
 ]
 
+# numpy is only a transitive dependency (nothing in src/ imports it) and its
+# stubs use PEP 695 `type` statements, which mypy refuses to parse while
+# python_version is 3.11. Skip them so mypy works from the 3.14 venv.
+[[tool.mypy.overrides]]
+module = ["numpy", "numpy.*"]
+follow_imports = "skip"
+follow_imports_for_stubs = true
+
 [tool.ruff]
 target-version = "py311"
 line-length = 88

--- a/src/mireport/localise.py
+++ b/src/mireport/localise.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import logging
-from decimal import Decimal
+from decimal import Decimal, localcontext
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -155,7 +155,8 @@ def localise_and_format_number(
 
     Raises:
         TypeError: If the number type is unsupported.
-        ValueError: If the string input cannot be converted to Decimal.
+        ValueError: If the string input cannot be converted to Decimal, or the
+            value is non-finite (NaN or Infinity).
     """
     # Normalize number to Decimal for safe formatting (avoids float artifacts)
     try:
@@ -173,24 +174,39 @@ def localise_and_format_number(
     except ValueError as e:
         raise ValueError(f"Invalid numeric string: {number}") from e
 
+    if not value.is_finite():
+        raise ValueError(f"Non-finite number cannot be formatted: {number}")
+
     if decimal_places == "INF":
         if locale:
-            return format_decimal(value, locale=locale, decimal_quantization=False)
+            # Babel derives its fractional precision from abs(exponent), so a
+            # positive exponent (e.g. Decimal("1E+30")) widens the quantum too.
+            exponent_digits = abs(int(value.as_tuple().exponent))
+            with localcontext() as ctx:
+                ctx.prec = max(ctx.prec, value.adjusted() + 1 + exponent_digits + 2)
+                return format_decimal(value, locale=locale, decimal_quantization=False)
         # No locale: use standard thousands separator, preserve full precision
         return f"{value:,}"
 
-    # Handle negative decimal places (fallback to 0)
-    decimal_places = max(decimal_places, 0)
+    # Handle negative decimal places (fallback to 0). Bound to a new name so the
+    # "INF" arm above stays narrowed away; reassigning decimal_places would widen
+    # it back to its declared DecimalPlaces union.
+    places = max(decimal_places, 0)
 
     # Normal finite case
     if locale:
-        pattern = "#,##0." + "0" * decimal_places if decimal_places > 0 else "#,##0"
-        return format_decimal(
-            value, format=pattern, locale=locale, decimal_quantization=True
-        )
+        pattern = "#,##0." + "0" * places if places > 0 else "#,##0"
+        # Babel quantizes in the active decimal context; the default 28-digit
+        # precision raises InvalidOperation for values whose formatted form
+        # needs more digits (integer digits + requested decimal places).
+        with localcontext() as ctx:
+            ctx.prec = max(ctx.prec, value.adjusted() + 1 + places + 2)
+            return format_decimal(
+                value, format=pattern, locale=locale, decimal_quantization=True
+            )
     else:
         # Use standard Python formatting without locale
-        return f"{value:,.{decimal_places}f}"
+        return f"{value:,.{places}f}"
 
 
 def decimal_symbol(locale: Locale | None = None) -> str:

--- a/src/mireport/report/fact.py
+++ b/src/mireport/report/fact.py
@@ -162,7 +162,7 @@ class Fact:
             output = localise_and_format_number(
                 number, decimal_places, self._report._outputLocale
             )
-        except (ValueError, TypeError) as e:
+        except (ValueError, TypeError, ArithmeticError) as e:
             raise InlineReportException(
                 f"Unexpected fact value {self.value=} for numeric concept {self.concept=}."
             ) from e

--- a/src/mireport/report/factbuilder.py
+++ b/src/mireport/report/factbuilder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from typing import TYPE_CHECKING
 
 from mireport.exceptions import InlineReportException
@@ -217,6 +218,10 @@ class FactBuilder:
             # N.B. bool extends int
             raise InlineReportException(
                 f"Unable to create numeric fact from non-numeric value {value=}"
+            )
+        if isinstance(value, float) and not math.isfinite(value):
+            raise InlineReportException(
+                f"Unable to create numeric fact from non-finite value {value=}"
             )
         if self._concept.isMonetary:
             units = self._aspects.get(

--- a/tests/unitTests/test_localise.py
+++ b/tests/unitTests/test_localise.py
@@ -92,3 +92,81 @@ def test_inf_with_locale(number, expected):
 def test_invalid_types(invalid_input):
     with pytest.raises(TypeError):
         localise_and_format_number(invalid_input, 2)
+
+
+@pytest.mark.parametrize(
+    "number,decimal_places,expected",
+    [
+        # Values needing more than 28 significant digits used to raise
+        # decimal.InvalidOperation from babel's quantize (default decimal
+        # context precision) when a locale was supplied.
+        (1e28, 0, "10,000,000,000,000,000,000,000,000,000"),
+        (1e30, 0, "1,000,000,000,000,000,000,000,000,000,000"),
+        (
+            "123456789012345678901234567890",
+            0,
+            "123,456,789,012,345,678,901,234,567,890",
+        ),
+        (1e30, 2, "1,000,000,000,000,000,000,000,000,000,000.00"),
+        # Modest value but many decimal places also exceeds 28 digits total
+        (Decimal(1234567), 25, "1,234,567." + "0" * 25),
+    ],
+)
+def test_huge_values_with_locale(number, decimal_places, expected):
+    result = localise_and_format_number(
+        number, decimal_places, locale=Locale("en", "US")
+    )
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "number,expected",
+    [
+        (1e30, "1,000,000,000,000,000,000,000,000,000,000"),
+        (
+            Decimal("123456789012345678901234567890.5"),
+            "123,456,789,012,345,678,901,234,567,890.5",
+        ),
+    ],
+)
+def test_huge_values_inf_with_locale(number, expected):
+    result = localise_and_format_number(number, "INF", locale=Locale("en", "US"))
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "number,decimal_places,expected",
+    [
+        # No-locale path uses plain f-string formatting; pin its behaviour
+        # for the same huge values.
+        (1e30, 0, "1,000,000,000,000,000,000,000,000,000,000"),
+        (
+            "123456789012345678901234567890",
+            0,
+            "123,456,789,012,345,678,901,234,567,890",
+        ),
+        (Decimal(1234567), 25, "1,234,567." + "0" * 25),
+    ],
+)
+def test_huge_values_no_locale(number, decimal_places, expected):
+    assert localise_and_format_number(number, decimal_places) == expected
+
+
+@pytest.mark.parametrize(
+    "non_finite",
+    [
+        Decimal("NaN"),
+        Decimal("Infinity"),
+        Decimal("-Infinity"),
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        "NaN",
+        "Infinity",
+    ],
+)
+@pytest.mark.parametrize("locale", [None, Locale("en", "US")])
+@pytest.mark.parametrize("decimal_places", [2, "INF"])
+def test_non_finite_values_raise(non_finite, locale, decimal_places):
+    with pytest.raises(ValueError):
+        localise_and_format_number(non_finite, decimal_places, locale=locale)

--- a/tests/unitTests/xlsx_template_reader/test_fact_creator_characterization.py
+++ b/tests/unitTests/xlsx_template_reader/test_fact_creator_characterization.py
@@ -19,7 +19,7 @@ import pytest
 
 from mireport.conversionresults import ConversionResultsBuilder, Severity
 from mireport.data.disclosures import VSME_DEFAULTS
-from mireport.exceptions import AmbiguousComponentException
+from mireport.exceptions import AmbiguousComponentException, InlineReportException
 from mireport.report import InlineReport
 from mireport.taxonomy import getTaxonomy, loadBuiltInTaxonomyJSON
 from mireport.xlsx_template_reader._binder import WorkbookBinder
@@ -665,6 +665,21 @@ class TestProcessNumeric:
             Messenger(creator_env.results), holder, _makeCell(12, "General"), fb, 12
         )
         assert fb._aspects.get("decimals") == "INF"
+
+
+class TestValidateNumericNonFinite:
+    @pytest.mark.parametrize(
+        "value", [float("nan"), float("inf"), float("-inf")], ids=str
+    )
+    def test_non_finite_values_rejected(self, creator_env, taxonomy, value):
+        concept = next(
+            c
+            for c in sorted(taxonomy.concepts, key=str)
+            if c.isReportable and c.isNumeric and not c.isMonetary
+        )
+        fb = creator_env.report.getFactBuilder().setConcept(concept).setValue(value)
+        with pytest.raises(InlineReportException, match="non-finite"):
+            fb.buildFact()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves #276

Run babel's `format_decimal()` inside a `localcontext()` with precision widened to what
the value needs, so values requiring more than 28 significant digits format instead of
raising `InvalidOperation`. Reject non-finite values in `localise_and_format_number()`
and `FactBuilder`. Catch `ArithmeticError` in `Fact._format_numeric_value()` so a
formatting failure reports the concept and value rather than a bare exception class.

Also skips numpy's PEP 695 stubs in mypy, which otherwise abort the run before it reaches
`src/`; unblocking it surfaced a `DecimalPlaces` narrowing error in `localise.py`, fixed
here.

Tests added for large magnitudes, large `decimals` counts, and non-finite values at both
format and fact-build time. Full suite green, including `integrationTests --run-slow`
(fact counts unchanged).
